### PR TITLE
Update 4.1.6 Release Notes to indicate DCC++ is broken

### DIFF
--- a/releasenotes/jmri4.1.6.shtml
+++ b/releasenotes/jmri4.1.6.shtml
@@ -57,7 +57,9 @@ see our
 
 <p>The Digitrax PR2 does not work with this release.  If you need to work with a 
 PR2, please stay with <a href="jmri4.1.3.shtml">JMRI 4.1.3</a> or earlier,
-or wait for <a href="jmri4.3.1.shtml">JMRI 4.3.1</a> which should appear in December 2015.
+or wait for <a href="jmri4.3.1.shtml">JMRI 4.3.1</a> which should appear in December 2015.</p>
+
+<p>DCC++ Support is broken in 4.1.6 (and 4.2.0).  Sorry!  If you need DCC++ support, please revert to 4.1.5 or wait for 4.3.1
 
 <!--
 If any of those effect you, please either wait for

--- a/releasenotes/jmri4.1.6.shtml
+++ b/releasenotes/jmri4.1.6.shtml
@@ -59,7 +59,7 @@ see our
 PR2, please stay with <a href="jmri4.1.3.shtml">JMRI 4.1.3</a> or earlier,
 or wait for <a href="jmri4.3.1.shtml">JMRI 4.3.1</a> which should appear in December 2015.</p>
 
-<p>DCC++ Support is broken in 4.1.6 (and 4.2.0).  Sorry!  If you need DCC++ support, please revert to 4.1.5 or wait for 4.3.1
+<p>DCC++ Support is broken in 4.1.6 (and 4.2.0).  Sorry!  If you need DCC++ support, please revert to 4.1.5 or wait for 4.3.1</p>
 
 <!--
 If any of those effect you, please either wait for


### PR DESCRIPTION
Update 4.1.6 Release Notes to indicate DCC++ support is broken and direct users to 4.1.5 or 4.3.1
