### PR TITLE
MRC 1961 - Decoder for Model Power N-scale Pacific/Mikado

### DIFF
--- a/releasenotes/jmri4.3.5.shtml
+++ b/releasenotes/jmri4.3.5.shtml
@@ -290,7 +290,7 @@ The <a href="https://github.com/JMRI/JMRI/issues?utf8=✓&q=is%3Aclosed&q=milest
 
         <h5>MRC</h5>
             <ul>
-                <li>MRC 1961 - Sound Decoder for Model Power N-scale Pacific/Mikado added (Alain LM / <a href="https://github.com/JMRI/JMRI/pull/1105">#1105</a>)</li>
+                <li>MRC 1961 - Sound Decoder for Model Power N-scale Pacific/Mikado added (Alain Le Marchand / <a href="https://github.com/JMRI/JMRI/pull/1105">#1105</a>)</li>
             </ul>
 
         <h5>NCE</h5>


### PR DESCRIPTION
Added full name of author in release note