### PR TITLE
updated release notes for Train-O-Matic decoders

### DIFF
--- a/releasenotes/jmri4.3.5.shtml
+++ b/releasenotes/jmri4.3.5.shtml
@@ -243,14 +243,15 @@ The <a href="https://github.com/JMRI/JMRI/issues?utf8=✓&q=is%3Aclosed&q=milest
                 <li>MRC 1825 - Athearn SD45/60 HO improved (Alain Le Marchand / <a href="https://github.com/JMRI/JMRI/pull/1140">#1140</a>)</li>
             </ul>
 
-        <h5>Norsk Modelljernbane (NJM)</h5>
+        <h5>Norsk Modelljernbane (NMJ)</h5>
             <ul>
-                <li>Norsk Modelljernbane (NJM) Topline decoders added (Lolke H Bijlsma / <a href="https://github.com/JMRI/JMRI/pull/1085">#1085</a>)</li>
+                <li>Norsk Modelljernbane (NMJ) Topline Skd 224 decoder added (Lolke H Bijlsma / <a href="https://github.com/JMRI/JMRI/pull/1085">#1085</a>)</li>
             </ul>
 
-        <h5>Miscellaneous</h5>
+        <h5>Train-O-Matic (tOm)</h5>
             <ul>
-                <li>Norsk Modelljernbane (NJM) Topline decoders added (Lolke H Bijlsma / <a href="https://github.com/JMRI/JMRI/pull/1085">#1085</a>)</li>
+                <li>tOm Lokommander Micro - added (Lolke H Bijlsma / <a href="https://github.com/JMRI/JMRI/pull/1109">#1109</a>)</li>
+                <li>tOm Lokommander Mini - added (Lolke H Bijlsma / <a href="https://github.com/JMRI/JMRI/pull/1109">#1109</a>)</li>
             </ul>
 
 


### PR DESCRIPTION
The 4.3.5 release notes weren't correctly describing the NMJ and tOm decoder updates.