### PR TITLE
Use correct hash sums

### DIFF
--- a/download/index.shtml
+++ b/download/index.shtml
@@ -106,15 +106,15 @@
 	<ul>
         <li>Mac OS X: <a
             href="https://sourceforge.net/projects/jmri/files/production%20files/JMRI.4.6-R81496dc.dmg/download">https://sourceforge.net/projects/jmri/files/production%20files/JMRI.4.6-R81496dc.dmg/download</a><br>
-            sha256: e4c8968ecc04a456b66438c0257055a69252feeb5051af8d3abde8dd127a6088</li>
+            sha256: 778086e641ef8d9c85d5f57f68fcccd60d721520dc3fc6eb54ed197f48f4b016</li>
 
         <li>Windows: <a
             href="https://sourceforge.net/projects/jmri/files/production%20files/JMRI.4.6-R81496dc.exe/download">https://sourceforge.net/projects/jmri/files/production%20files/JMRI.4.6-R81496dc.exe/download</a><br>
-            sha256: b78061d2d98820d4e448c669dcf6f9e299bb82fd71d782f6a94e9f0ff8331e49</li>
+            sha256: af9847a7dc9e62ec44a70fbae1cdea2c291ad8e31422c8f3c648186862c54442</li>
 
         <li>Linux: <a
             href="https://sourceforge.net/projects/jmri/files/production%20files/JMRI.4.6-R81496dc.tgz/download">https://sourceforge.net/projects/jmri/files/production%20files/JMRI.4.6-R81496dc.tgz/download</a><br>
-            sha256: 48c21a895344bf5e0a7f736ab69294fb3f0b00db7fa1e393e2365eda104d0c98</li>
+            sha256: 81c642347dc1bf8c4abf93c19385845e637ce801be68ab6aaf1d5fd9a5eded37</li>
       </ul>
       </p>
 


### PR DESCRIPTION
User noticed these hash sums did not match the downloads - copy in hash sums from https://github.com/JMRI/JMRI/releases/tag/v4.6 which do match.