### PR TITLE
Update jmri4.7.1.shtml

### DIFF
--- a/releasenotes/jmri4.7.1.shtml
+++ b/releasenotes/jmri4.7.1.shtml
@@ -545,9 +545,10 @@ The <a href="https://github.com/JMRI/JMRI/issues?utf8=✓&q=is%3Aclosed&q=milest
    <h4>Virtual Sound Decoder</h4>
         <ul>
             <li>VSDecoder Manager can now be auto-launched at startup through preferences.</li>
-	    <li>Five new diesel and steam engine sound sets were added at https://github.com/JMRI/vsdecoder (provided by Klaus Killinger).</li>
+            <li>New location for sound sets was added at https://github.com/JMRI/vsdecoder.</li>
+            <li>New steam engine sound set Class64.vsd was added (provided by Klaus Killinger).</li>
         </ul>
-        
+
     <h4>Miscellaneous</h4>
         <ul>
             <li>For those connections which have the ability to monitor the bus traffic, the


### PR DESCRIPTION
@rhwood You're much too kind. Four of those five VSD files were created and pubished earlier by @msunderwd bundled as "example.vsd". I just split the bundle into four files and did the upload to JMRI/vsdecoder.
New is the location "JMRI/vsdecoder" for such sound samples. My contribution is that new steam engine sample named Class64.vsd.

Please feel free to change my new proposal, as I'm not very experienced in wording things.

Thank you!