### PR TITLE
Rationalize 'release' vs 'version' terminology

### DIFF
--- a/download/Sidebar
+++ b/download/Sidebar
@@ -66,7 +66,7 @@
   <dt><h3><a href="../releasenotes/">Release Notes</a></h3></dt>
   <dd>
 	<ul>
-	<li>Production Versions:
+	<li>Production Releases:
 	    <ul>
 	    <li><a href="../releasenotes/jmri4.6.shtml">JMRI 4.6</a>
 	    <li><a href="../releasenotes/jmri4.4.shtml">JMRI 4.4</a>
@@ -76,7 +76,7 @@
 	    <li><a href="../releasenotes/jmri2.14.1.shtml">JMRI 2.14.1</a>
 	    <li><a href="older.html">Older releases</a>
 	    </ul></li>
-	<li>Test Versions:
+	<li>Test Releases:
 	    <ul>
 	    <li><a href="../releasenotes/jmri4.5.8.shtml">JMRI 4.5.8</a>
 	    <li><a href="../releasenotes/jmri4.5.7.shtml">JMRI 4.5.7</a>
@@ -94,7 +94,7 @@
 
 	    <li><a href="older.html">Older releases</a>
 	    </ul></li>
-	<li>(Tentative) Next Test Version:</li>
+	<li>(Tentative) Next Test Release:</li>
 	    <ul>
 	    <li><a href="../releasenotes/jmri4.7.1.shtml">JMRI 4.7.1</a>
       </ul>

--- a/download/index.shtml
+++ b/download/index.shtml
@@ -37,59 +37,58 @@
         if you want quick access to some particular fix, but please note that they're
         not fully tested. Test releases get more testing as part of the release process.
     </ul>
-    </div>
+    </div><!-- closes #teaser-->
 	<h1>Latest News</h1>
 	<dl>
-		<dt>Production version 4.6 released</dt>
+		<dt>Production release 4.6 available</dt>
 	    <dd>
-	    <p>On December 17, 2016 production version 4.6 was made available.</p>
+	    <p>On December 17, 2016 production release 4.6 was made available.</p>
 	    
 	    <p>
-	    Version 4.6 is the current "production" version, recommended
+	    Release 4.6 is the current "production" release, recommended
 	    for first-time users.
 	    Please see the 
 	    <a href="#prod-rel">next section</A> for download and install
 	    information. 
 	    
-	    <dt>Test version 4.5.8 released</dt>
+	    <dt>Test release 4.5.8 available</dt>
 	    <dd>
-	    <p>Test version 4.5.8 was made available on December 14, 2016.
+	    <p>Test release 4.5.8 was made available on December 14, 2016.
 
         <p>JMRI 4.5.8 is the next test release in the current development series, containing the latest
         and greatest JMRI updates. 
         <p>
-        The series is working toward the next JMRI production version, probably in December 2016.
+        The series is working toward the next JMRI production release, probably in December 2016.
         <p>
         For more
 	    information, including the links to download a copy,
 	    please see the
 	    <a href="../releasenotes/jmri4.5.8.shtml">release note</a>.
 	  
-	    <a href="#prod-rel">Version 4.6</a> is the current "production" version, recommended
+	    <a href="#prod-rel">Release 4.6</a> is the current "production" release, recommended
 	    for first-time users. 
 
-		<dt>Production version 3.10.1 released</dt>
+		<dt>Production release 3.10.1 available</dt>
 	    <dd>
-	    <p>On January 11, 2015 production version 3.10.1 was made available.</p>
+	    <p>On January 11, 2015 production release 3.10.1 was made available.</p>
 	    
 	    <p>
-	    Version 3.10.1 is recommended for JMRI users with computers that can only
+	    Release 3.10.1 is recommended for JMRI users with computers that can only
 	    run Java 1.6. Please see the 
 	    <a href="../releasenotes/jmri3.10.1.shtml">release note</A> for download and install
 	    information. 
  
-		<dt>Production version 2.14.1 released</dt>
+		<dt>Production release 2.14.1 available</dt>
 	    <dd>
-	    <p>On July 15, 2012 production version 2.14.1 was made available.</p>
+	    <p>On July 15, 2012 production release 2.14.1 was made available.</p>
 	    
 	    <p>
-	    Version 2.14.1 is recommended for JMRI users with computers that can only
+	    Release 2.14.1 is recommended for JMRI users with computers that can only
 	    run Java 1.5. Please see the 
 	    <a href="../releasenotes/jmri2.14.1.shtml">release note</A> for download and install
 	    information. 
  
 	</dl>
-    </div>
 
   <div class="list">
     <a id="prod-rel"></a>
@@ -148,7 +147,7 @@
 
     <a id="test-rel"></a>
     <h2>JMRI - Test Releases</h2>
-    <p>As the program develops, we also produce test versions. You may
+    <p>As the program develops, we also produce test releases. You may
 	    want to try these, as new features will show up in them first. They
 	    are announced in the
 	    <a href="https://groups.yahoo.com/neo/groups/jmriusers/info">JMRI users</a> Yahoo group.</p>

--- a/index.html
+++ b/index.html
@@ -220,32 +220,32 @@ JMRI: A Java Model Railroad Interface
         <table border=0>
 	    <tr><td width="50%" valign=top>    
 
-			<h2><a name="download"><a href="/download/index.shtml#prod-rel">JMRI 4.6 Production Version</a></h2>
+			<h2><a name="download"><a href="/download/index.shtml#prod-rel">JMRI 4.6 Production Release</a></h2>
 				Released on December 17, 2016.
 				<p>
 				JMRI 4.6 is recommended for new users. It's the most
-				recent stable production version.
+				recent stable production release.
 			  </p>
 				<p class="dl">For more information, please read the
 				<a href="releasenotes/jmri4.6.shtml">JMRI 4.6 Release Note</a>, 
 				which also contains the download links.</p>
 
-			<h2><a href="releasenotes/jmri3.10.1.shtml">JMRI 3.10.1 Production Version</a></h2>
+			<h2><a href="releasenotes/jmri3.10.1.shtml">JMRI 3.10.1 Production Release</a></h2>
 				Released on January 11, 2015.
 				<p>
 				JMRI 3.10.1 is recommended for JMRI users with computers
-                that can only run Java 1.6; later versions require Java 1.8.
+                that can only run Java 1.6; later releases require Java 1.8.
 				
 			    </p>
 				<p class="dl">For more information, please read the
 				<a href="releasenotes/jmri3.10.1.shtml">JMRI 3.10.1 Release Note</a>, 
 				which also contains the download links.</p>
 
-			<h2><a href="releasenotes/jmri2.14.1.shtml">JMRI 2.14.1 Production Version</a></h2>
+			<h2><a href="releasenotes/jmri2.14.1.shtml">JMRI 2.14.1 Production Release</a></h2>
 				Released on July 15, 2012.
 				<p>
 				JMRI 2.14.1 is recommended for JMRI users with computers
-				that can only run Java 1.5; later versions require Java 1.6/1.8.
+				that can only run Java 1.5; later releases require Java 1.6/1.8.
 				
 			    </p>
 				<p class="dl">For more information, please read the
@@ -257,14 +257,14 @@ JMRI: A Java Model Railroad Interface
             <h2><a href="releasenotes/jmri4.5.8.shtml">JMRI 4.5.8 Test Release</a></h2>
                 Released on December 14, 2016.
                 <p>
-                This is the next in a series working toward the next JMRI production version
+                This is the next in a series working toward the next JMRI production release
                 in late 2016.
                 <p>
                 For more information on this test release, please read the
                <a href="releasenotes/jmri4.5.8.shtml">JMRI 4.5.8 Release Note</a>,
                     which also contains the download links.
                  </p>
-                <a href="#download">Version 4.6</a> is the current "production" version, recommended
+                <a href="#download">Release 4.6</a> is the current "production" release, recommended
                 for first-time users. 
 
     </td></tr></table>

--- a/releasenotes/jmri4.6.shtml
+++ b/releasenotes/jmri4.6.shtml
@@ -28,13 +28,13 @@
 
     <p>Date: December 17, 2016</p>
     <p>From: Bob Jacobsen</p>
-    <p>Subject: Production version 4.6 of JMRI/DecoderPro is available for download.</p>
+    <p>Subject: Production Release 4.6 of JMRI/DecoderPro is available for download.</p>
 
 <!-- <p><b>This is a draft release note only; the download links do not yet work</b></p> -->
 
 We are very pleased to announce that the 4.5 series of JMRI test releases has resulted in a
 version that's good enough to be recommended for general use, including by new users.
-We're therefore making that version, "Production version 4.6" available for download today.
+We're therefore making that version, "Production Release 4.6" available for download today.
 
 <h3>Notes:</h3>
 
@@ -63,7 +63,7 @@ from
 
 
 <a id="warnings" name="warnings"></a>
-<h3>New warnings for this version:</h3>
+<h3>New warnings for this release:</h3>
 
 <ul>
     <li>None at release time</a>
@@ -96,7 +96,7 @@ These may be relevant to you if you're updating from an earlier version.
         TMCC connection is selected for the appropriate device types.
 
 <p><em>(Since JMRI 4.5.2)</em>
-    This and future versions of JMRI may not function on OS X if the Java SE 6 provided by Apple is installed. OS X
+    This and future releases of JMRI may not function on OS X if the Java SE 6 provided by Apple is installed. OS X
     operating system updates routinely remove this version of Java SE 6. Please raise any issues concerning this on the
     user's group.
     <p>To remove Java SE 6 from OS X, follow these steps (these steps assume
@@ -134,7 +134,7 @@ These may be relevant to you if you're updating from an earlier version.
     automatically migrate them to new names when saved, but in some cases you might need to manually update them.
 
 <p><em>(Since JMRI 4.3.5)</em>
-    When sharing a configuration between this version and JMRI 4.3.4 or older, the older version of JMRI will not
+    When sharing a configuration between this release and JMRI 4.3.4 or older, the older version of JMRI will not
     reflect changes in preferences, window position, table sorting, column order, or other user interface state. This is due to
     changes in how user preferences and interface state are stored.
 
@@ -268,7 +268,7 @@ in our
                     connected to the same layout to be respected in the JMRI Turnout's state. New turnouts
                     created with JMRI 4.5.6 or later will default to MONITORING feedback. Turnouts created
                     with older versions of JMRI or turnouts in panel XML files saved by older versions of
-                    JMRI will be set to DIRECT feedback mode, and users of version 4.5.6 and above will have
+                    JMRI will be set to DIRECT feedback mode, and users of release 4.5.6 and above will have
                     to edit the turnouts one by one to set the desired feedback mode to MONITORING if they
                     wish to use the new behavior.</li>
                 <li>Improvements in the standards compliancy of JMRI Turnouts and Sensors; these will now

--- a/releasenotes/jmri4.7.0.shtml
+++ b/releasenotes/jmri4.7.0.shtml
@@ -28,7 +28,7 @@
 
     <p>Date: mmm dd, 2017</p>
     <p>From: (pumpkin)</p>
-    <p>Subject: Test version 4.7.0 of JMRI/DecoderPro is available for download.</p>
+    <p>Subject: Test Release 4.7.0 of JMRI/DecoderPro is available for download.</p>
 
 <p><b>This is a draft release note only; the download links do not yet work</b></p>
 
@@ -43,7 +43,7 @@ new serial library.  The content is very similar to JMRI 4.6.</p>
 
 <p>Some of the changes involved are quite extensive.
 They may require a certain amount of experience before they are working well.
-Therefore, this test version should be considered experimental.</p>
+Therefore, this test release should be considered experimental.</p>
 
 <p><b>
 JMRI is now only available under the
@@ -67,10 +67,10 @@ from
  -->
 
 <a id="warnings" name="warnings"></a>
-<h3>New warnings for this version:</h3>
+<h3>New warnings for this release:</h3>
 
 <ul>
-    <li>The serial interface library has changed in this version. This has the following known effects:
+    <li>The serial interface library has changed in this release. This has the following known effects:
         <ul>
             <li>The Digitrax MS100 is expected to be usable on all supported platforms.</li>
             <li>The JMRI_SERIAL_PORTS environment variable and --serial-ports command line argument are ignored. These
@@ -93,7 +93,7 @@ These may be relevant to you if you're updating from an earlier version.
         pane in the Preferences window and make sure that the 
         TMCC connection is selected for the appropriate device types.
 
-<p><em>(Since JMRI 4.5.2)</em>This and future versions of JMRI may not function on OS X if the Java SE 6 provided by Apple is installed. OS X
+<p><em>(Since JMRI 4.5.2)</em>This and future releases of JMRI may not function on OS X if the Java SE 6 provided by Apple is installed. OS X
     operating system updates routinely remove this version of Java SE 6. Please raise any issues concerning this on the
     user's group.
     <p>To remove Java SE 6 from OS X, follow these steps (these steps assume

--- a/releasenotes/jmri4.7.1.shtml
+++ b/releasenotes/jmri4.7.1.shtml
@@ -28,7 +28,7 @@
 
     <p>Date: mmm dd, 2017</p>
     <p>From: (pumpkin)</p>
-    <p>Subject: Test version 4.7.1 of JMRI/DecoderPro is available for download.</p>
+    <p>Subject: Test Release 4.7.1 of JMRI/DecoderPro is available for download.</p>
 
 <p><b>This is a draft release note only; the download links do not yet work</b></p>
 
@@ -38,13 +38,13 @@
 And please back up your JMRI files before installing this, in case you want to go
 back to an earlier version.</p>
 
-<p>This is the first in a series of test versions. We expect this series
+<p>This is the first in a series of test releases. We expect this series
 to end in the next JMRI production release around the middle of 2017.
 (See the <a href="https://github.com/JMRI/JMRI/milestones?state=open"><em>tentative</em> release schedule</a>)</p>
 
 <p>Some of the changes involved are quite extensive.
 They may require a certain amount of experience before they are working well.
-Therefore, this test version should be considered experimental.</p>
+Therefore, this test release should be considered experimental.</p>
 
 <p><b>
 JMRI is now only available under the
@@ -68,7 +68,7 @@ from
  -->
 
 <a id="warnings" name="warnings"></a>
-<h3>New warnings for this version:</h3>
+<h3>New warnings for this release:</h3>
 
 <ul>
     <li>JMRI no longer supports the portable paths <pre>resource:</pre> or <pre>file:</pre> that
@@ -95,7 +95,7 @@ These may be relevant to you if you're updating from an earlier version.
         pane in the Preferences window and make sure that the 
         TMCC connection is selected for the appropriate device types.
 
-<p><em>(Since JMRI 4.5.2)</em>This and future versions of JMRI may not function on OS X if the Java SE 6 provided by Apple is installed. OS X
+<p><em>(Since JMRI 4.5.2)</em>This and future releases of JMRI may not function on OS X if the Java SE 6 provided by Apple is installed. OS X
     operating system updates routinely remove this version of Java SE 6. Please raise any issues concerning this on the
     user's group.
     <p>To remove Java SE 6 from OS X, follow these steps (these steps assume


### PR DESCRIPTION
Based on some confusion in email discussions, trying to move toward:

- Always refer to 'release 4.6' as a "_release_": "Release 4.6 was made available", "Release 4.6 was from December"
- Non-released code is called a "_version_": "get the most recent version from the development build web page" 
- The generic term  is version: "Any prior version of JMRI"

Edits to various web pages, including release notes back to 4.6 (but not before)