### PR TITLE
Propose background color for "since" tag

### DIFF
--- a/css/default.css
+++ b/css/default.css
@@ -196,9 +196,9 @@
 	}
 
 	span.since {
-		color: #fff;
+		color: #554FA0;
 		float: right;
-		background: #222696;
+		background: #EEECF6;
 	    background-size: 100% 100%;
 	    border-radius: 4px;
 	    margin: 2px 2px 2px 2px;


### PR DESCRIPTION
@silverailscolo added a very nice "since" tag to JMRI's CSS, which allows highlighting when something was added.  It's now in the [JMRI 4.7.4 (draft) release note](http://jmri.org/releasenotes/jmri4.7.4.shtml).

This PR proposes changing the background color from a darker blue (similar to our [WIP label in the code repository](https://github.com/JMRI/JMRI/labels)):

![skitch](https://cloud.githubusercontent.com/assets/2774117/26026033/fa5f6072-37a8-11e7-9a9a-f7a9b0075b6f.png)

to the same CSS color as the headings and highlights on the web pages:

![skitch](https://cloud.githubusercontent.com/assets/2774117/26026037/0e2a0616-37a9-11e7-8c4d-34a3ddea753e.png)

so that the black text of the links doesn't get lost.

I definitely see the attention-getting nature of the deeper blue.  Making it lighter loses some of the highlight value.  As an alternative to making the background lighter blue to show the link, could we figure out a way to make the links show as white/light text only when inside a "since"? That would be even better than this PR, but my CSS-fu apparently isn't good enough to see a way to do that.