### PR TITLE
Update jmri4.9.4.shtml

### DIFF
--- a/releasenotes/jmri4.9.4.shtml
+++ b/releasenotes/jmri4.9.4.shtml
@@ -340,7 +340,7 @@ The <a href="https://github.com/JMRI/JMRI/issues?utf8=✓&q=is%3Aclosed&q=milest
 
         <h4>RFID</h4>
             <ul>
-                <li></li>
+                <li>Support for the Olimex MOD-RFID1356MIFARE has been added.</li>
             </ul>
 
         <h4>Roco z21/Z21</h4>


### PR DESCRIPTION
Notes the added support for Olimex MOD-RFID1356MIFARE readers.