### PR TITLE
Uhlenbrock configuration profile baud rate issues

### DIFF
--- a/releasenotes/jmri4.9.5.shtml
+++ b/releasenotes/jmri4.9.5.shtml
@@ -237,6 +237,18 @@ These may be relevant to you if you're updating from an earlier version.
     "IT12" is fine, but just "IT" is not. Most panel files that contain these should
     automatically migrate them to new names when saved, but in some cases you might need to manually update them.
 
+<p><span class="since">Since <a href="jmri4.9.2.shtml">JMRI 4.9.2</a></span>
+    JMRI saves the Uhlenbrock connection's "baud" rate as an Internationalized string, 
+    and, upon loading a configuration profile, requires an Internationalized "baud" 
+    rate in the .XML file.  JMRI will fail to properly configure the serial port if the
+    "baud" rate from the configuration profile does not match one of the baud rate 
+    strings for the current Internationalization "locale".  If you experience problems 
+    where JMRI start-up of a Uhlenbrock-based connection does not configure the serial 
+    port, it may be necessary to edit the connection's preferences, select the 
+    appropriate "baud" rate, save the connection.  This updates the configuration profile 
+    .XML file to use one of the "baud" rate strings expected by the Uhlenbrock-specific 
+    code in JMRI.  It is necessary to re-start JMRI for this change to take effect.
+
 <a id="download" name="download"></a>
 <h2>Download links:</h2>
 
@@ -362,7 +374,9 @@ The <a href="https://github.com/JMRI/JMRI/issues?utf8=✓&q=is%3Aclosed&q=milest
 
         <h4>Uhlenbrock Intellibox</h4>
             <ul>
-                <li></li>
+                <li>Initial creation of a JMRI conneciton to a Uhlenbrock command station now saves
+		the default serial port "baud" rate in a format which can be properly read by the 
+		Uhlenbrock connection.</li>
             </ul>
 
         <h4>Zimo MXULF</h4>


### PR DESCRIPTION
Add user-level workaround for Uhlenbrock configuration profile baud rate issue (since 4.9.2).
Add change to Uhlenbrock "default" baud rate.