### PR TITLE
Uhlenbrock connection I18N changes, workaround

### DIFF
--- a/releasenotes/jmri4.9.2.shtml
+++ b/releasenotes/jmri4.9.2.shtml
@@ -102,6 +102,17 @@ their library references:
         directory that can cause this.  The work-around is to go to the profile directory
         and remove that file.  JMRI will recreate it if it needs it.
     </li>
+    <li>JMRI now saves the Uhlenbrock connection's "baud" rate as an Internationalized string, 
+    and, upon loading a configuration profile, requires an Internationalized "baud" 
+    rate in the .XML file.  JMRI will fail to properly configure the serial port if the
+    "baud" rate from the configuration profile does not match one of the baud rate 
+    strings for the current Internationalization "locale".  If you experience problems 
+    where JMRI start-up of a Uhlenbrock-based connection does not configure the serial 
+    port, it may be necessary to edit the connection's preferences, select the 
+    appropriate "baud" rate, and save the connection.  This updates the configuration profile 
+    .XML file to use one of the "baud" rate strings expected by the Uhlenbrock-specific 
+    code in JMRI.  It is necessary to re-start JMRI for this change to take effect.</li>
+
 </ul>
 
 If this affects you, please either 


### PR DESCRIPTION
Describes a workaround for the case where a Uhlenbrock configuration profile cannot configure the serial port resulting from I18N efforts.