### PR TITLE
Update to location of new jmri-developers list

### DIFF
--- a/contact/index.shtml
+++ b/contact/index.shtml
@@ -30,18 +30,18 @@
      even complaints, post them here.</p>
 
   <p>In addition to the above user community, there are several developer
-  focused mailing lists hosted on sourceforge.net that you may find useful:</p>
+  focused mailing lists hosted on Groups.io that you may find useful:</p>
   <ul>
-	<li> <a href="https://sourceforge.net/mailarchive/forum.php?forum_name=jmri-announce">jmri-announce Archives</a>
-	(<a href="https://lists.sourceforge.net/mailman/listinfo/jmri-announce">Subscribe</a>)
+	<li> <a href="https://groups.io/g/jmri-announce/topics">jmri-announce Archives</a>
+	(<a href="https://groups.io/g/jmri-announce/join">Subscribe</a>)
 	&nbsp;Announcements of new JMRI versions.</li>
 	
-	<li> <a href="https://sourceforge.net/mailarchive/forum.php?forum_name=jmri-commits">jmri-commits Archives</a>
-	(<a href="https://lists.sourceforge.net/mailman/listinfo/jmri-commits">Subscribe</a>)
+	<li> <a href="https://jmri-developers.groups.io/g/commits/topics">jmri-commits Archives</a>
+	(<a href="https://jmri-developers.groups.io/g/commits/join">Subscribe</a>)
 	&nbsp;CVS/Git commit notifications.</li>
 
-	<li><a href="https://sourceforge.net/mailarchive/forum.php?forum_name=jmri-developers">jmri-developers Archives</a>
-	(<a href="https://lists.sourceforge.net/mailman/listinfo/jmri-developers">Subscribe</a>)
+	<li><a href="https://jmri-developers.groups.io/g/jmri/topics">jmri-developers Archives</a>
+	(<a href="https://jmri-developers.groups.io/g/jmri/join">Subscribe</a>)
 	&nbsp;Discussion of current and future development.</li>
   </ul>	
 

--- a/index.shtml
+++ b/index.shtml
@@ -176,8 +176,8 @@ JMRI: A Java Model Railroad Interface
 			<li> <strong>Help extend and develop it</strong> (look 
 			    <a href="/help/en/html/doc/Technical/index.shtml" title="Developing and extending JMRI">under the hood</a>,
 			    <a href="http://jmri.org/help/en/html/doc/Technical/getcode.shtml">get the source code</a>,
-				<a href="https://lists.sourceforge.net/lists/listinfo/jmri-developers">join</a> or
-				<a href="http://sourceforge.net/p/jmri/mailman/jmri-developers/">browse</a>
+				<a href="https://jmri-developers.groups.io/g/jmri/join">join</a> or
+				<a href="https://jmri-developers.groups.io/g/jmri/topics">browse</a>
 				the JMRI-Developers mailing list) 
 			<li>Or <a href="/donations.shtml">make a small donation</a> to help defray the costs of keeping this going.
 			</ul>


### PR DESCRIPTION
This updates (most) references to the jmri-developers list ready for when we move it to Groups.io