### PR TITLE
Fix Mac OS X 10.6 name

### DIFF
--- a/install/MacOSX.shtml
+++ b/install/MacOSX.shtml
@@ -57,7 +57,7 @@
        If your Mac hardware doesn't let you update MacOS X to a recent enough version,
        you can still use older versions of JMRI:
        <ul>
-        <li>Mac OS X version 10.7.2 "Lion" through 10.6 "Mountain Lion" can run <a href="http://jmri.org/releasenotes/jmri3.10.1.shtml">JMRI 3.10.1</a> using Java 1.7.
+        <li>Mac OS X version 10.7.2 "Lion" through 10.6 "Snow Leopard" can run <a href="http://jmri.org/releasenotes/jmri3.10.1.shtml">JMRI 3.10.1</a> using Java 1.7.
             (The youngest Mac that can't run Mountain Lion was shipped in 2009)
         <li>Mac OS X version 10.5 "Leopard" through 10.4 "Tiger" can run <a href="http://jmri.org/releasenotes/jmri2.14.1.shtml">JMRI 2.14.1</a> using Java 1.6.
             (The youngest Mac that can't run Tiger was shipped in 2003)


### PR DESCRIPTION
Mac OS 10.6 is "Snow Leopard" not "Mountain Lion"

Fix issue #300