### PR TITLE
Switch fragment files to .shtml suffix

### DIFF
--- a/community/clinics/UK2011/Hardware.shtml
+++ b/community/clinics/UK2011/Hardware.shtml
@@ -19,7 +19,7 @@
 <div>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 <h2>Signal Mast Logic - Layout Hardware</h2>
 <p>The choice of hardware for a signalling project is very open, there are lots 

--- a/community/connections/ManifestCreator/index.shtml
+++ b/community/connections/ManifestCreator/index.shtml
@@ -32,7 +32,7 @@
         For more information, see the
         <a href="http://manifestcreator.weebly.com">Manifest Creator web site</a>.
      
-      <!--#include virtual="/Footer" -->
+      <!--#include virtual="/Footer.shtml" -->
     </div><!-- close #mainContent -->
   </div><!-- close #mBody -->
 </body>

--- a/community/connections/ManifestCreator/index.shtml
+++ b/community/connections/ManifestCreator/index.shtml
@@ -18,7 +18,7 @@
 </head>
 
 <body>
-  <!--#include virtual="/Header" -->
+  <!--#include virtual="/Header.shtml" -->
   <div id="mBody">
     <!--#include virtual="../Sidebar.shtml" -->
     <div id="mainContent">

--- a/community/connections/TrainCrew/index.shtml
+++ b/community/connections/TrainCrew/index.shtml
@@ -52,7 +52,7 @@
      <p>TrainCrew code is available on <a href="https://github.com/ekapus/TrainCrew">GitHub here.</a>
      </p>
      
-      <!--#include virtual="/Footer" -->
+      <!--#include virtual="/Footer.shtml" -->
     </div><!-- close #mainContent -->
   </div><!-- close #mBody -->
 </body>

--- a/community/connections/TrainCrew/index.shtml
+++ b/community/connections/TrainCrew/index.shtml
@@ -20,7 +20,7 @@
 </head>
 
 <body>
-  <!--#include virtual="/Header" -->
+  <!--#include virtual="/Header.shtml" -->
   <div id="mBody">
     <!--#include virtual="../Sidebar.shtml" -->
     <div id="mainContent">

--- a/donations.shtml
+++ b/donations.shtml
@@ -16,7 +16,7 @@
 </head>
 
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 
 <hr class="hide">
 

--- a/download/index.shtml
+++ b/download/index.shtml
@@ -21,7 +21,7 @@
 <p class="skipLink"><a href="#mainContent" accesskey="2">Skip to main content</a></p>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 
  <hr class="hide"> 
  <div id="mainContent">

--- a/install/Debug.shtml
+++ b/install/Debug.shtml
@@ -15,7 +15,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="/download/Sidebar" -->
+<!--#include virtual="/download/Sidebar.shtml" -->
 
 <div id="mainContent">
 

--- a/install/EeePC.shtml
+++ b/install/EeePC.shtml
@@ -19,7 +19,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="/download/Sidebar" -->
+<!--#include virtual="/download/Sidebar.shtml" -->
 
 <div id="mainContent">
 

--- a/install/FAQLinux.shtml
+++ b/install/FAQLinux.shtml
@@ -24,7 +24,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="/download/Sidebar" -->
+<!--#include virtual="/download/Sidebar.shtml" -->
   <div id="mainContent">
 
 <h1>

--- a/install/Linux.shtml
+++ b/install/Linux.shtml
@@ -20,7 +20,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="/download/Sidebar" -->
+<!--#include virtual="/download/Sidebar.shtml" -->
   <div id="mainContent">
   
   <h1>JMRI Install Guide: Linux</h1>

--- a/install/MacOSLocations.shtml
+++ b/install/MacOSLocations.shtml
@@ -15,7 +15,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="/download/Sidebar" -->
+<!--#include virtual="/download/Sidebar.shtml" -->
 
 <div id="mainContent">
 

--- a/install/MacOSX.shtml
+++ b/install/MacOSX.shtml
@@ -18,7 +18,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="/download/Sidebar" -->
+<!--#include virtual="/download/Sidebar.shtml" -->
 <div id="mainContent">
   <h1>JMRI Install Guide: macOS</h1>
 

--- a/install/MacOSXrmLibs.shtml
+++ b/install/MacOSXrmLibs.shtml
@@ -20,7 +20,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="/download/Sidebar" -->
+<!--#include virtual="/download/Sidebar.shtml" -->
 <div id="mainContent">
       <h1> 
        JMRI: Mac OS X Install: Remove Old Libraries

--- a/install/Mint.shtml
+++ b/install/Mint.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="/download/Sidebar" -->
+<!--#include virtual="/download/Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1> 

--- a/install/OLPC_XO.shtml
+++ b/install/OLPC_XO.shtml
@@ -20,7 +20,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="/download/Sidebar" -->
+<!--#include virtual="/download/Sidebar.shtml" -->
 
 <div id="mainContent">
 

--- a/install/OpenSUSE.shtml
+++ b/install/OpenSUSE.shtml
@@ -18,7 +18,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="/download/Sidebar" -->
+<!--#include virtual="/download/Sidebar.shtml" -->
 
 <div id="mainContent">
 

--- a/install/Raspbian.shtml
+++ b/install/Raspbian.shtml
@@ -15,7 +15,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="/download/Sidebar" -->
+<!--#include virtual="/download/Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Installing JMRI on Raspbian</h1>

--- a/install/USB.shtml
+++ b/install/USB.shtml
@@ -15,7 +15,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="/download/Sidebar" -->
+<!--#include virtual="/download/Sidebar.shtml" -->
 
 <div id="mainContent">
 

--- a/install/Ubuntu.shtml
+++ b/install/Ubuntu.shtml
@@ -15,7 +15,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="/download/Sidebar" -->
+<!--#include virtual="/download/Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>JMRI Install Guide: Ubuntu Linux</h1>

--- a/install/Win64.shtml
+++ b/install/Win64.shtml
@@ -15,7 +15,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="/download/Sidebar" -->
+<!--#include virtual="/download/Sidebar.shtml" -->
 
 <div id="mainContent">
 

--- a/install/WindowsLocations.shtml
+++ b/install/WindowsLocations.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="/download/Sidebar" -->
+<!--#include virtual="/download/Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>JMRI File Locations on Windows</h1>

--- a/install/WindowsNew.shtml
+++ b/install/WindowsNew.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="/download/Sidebar" -->
+<!--#include virtual="/download/Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1> 

--- a/install/WindowsSeStoppedWorking.shtml
+++ b/install/WindowsSeStoppedWorking.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="/download/Sidebar" -->
+<!--#include virtual="/download/Sidebar.shtml" -->
 <div id="mainContent">
 <h1> 
 JMRI on Windows: "The JAVA SE Platform binary has stopped working" error

--- a/install/decTOPvideo.shtml
+++ b/install/decTOPvideo.shtml
@@ -18,7 +18,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="/download/Sidebar" -->
+<!--#include virtual="/download/Sidebar.shtml" -->
 <div id="mainContent">
 
 	    <!-- ------------- -->

--- a/install/decTop.shtml
+++ b/install/decTop.shtml
@@ -19,7 +19,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="/download/Sidebar" -->
+<!--#include virtual="/download/Sidebar.shtml" -->
 <div id="mainContent">
 
 	    <!-- ------------- -->

--- a/install/espeak.shtml
+++ b/install/espeak.shtml
@@ -19,7 +19,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="/download/Sidebar" -->
+<!--#include virtual="/download/Sidebar.shtml" -->
 
 <div id="mainContent">
 

--- a/manual/3-0_DecoderPro/Adv_FunctionLabel.shtml
+++ b/manual/3-0_DecoderPro/Adv_FunctionLabel.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Adv_RosterMedia.shtml
+++ b/manual/3-0_DecoderPro/Adv_RosterMedia.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Adv_start.shtml
+++ b/manual/3-0_DecoderPro/Adv_start.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
   <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Basic_BasicPane.shtml
+++ b/manual/3-0_DecoderPro/Basic_BasicPane.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Basic_Mode.shtml
+++ b/manual/3-0_DecoderPro/Basic_Mode.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Programming Modes
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Basic_Programming.shtml
+++ b/manual/3-0_DecoderPro/Basic_Programming.shtml
@@ -19,7 +19,7 @@ Using DecoderPro&reg;
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Using DecoderPro&reg;</h1>

--- a/manual/3-0_DecoderPro/Basic_Start.shtml
+++ b/manual/3-0_DecoderPro/Basic_Start.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>The Basic Programmer</h1>

--- a/manual/3-0_DecoderPro/Comp_Advanced.shtml
+++ b/manual/3-0_DecoderPro/Comp_Advanced.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Comp_Analog.shtml
+++ b/manual/3-0_DecoderPro/Comp_Analog.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Comp_Basic.shtml
+++ b/manual/3-0_DecoderPro/Comp_Basic.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Comp_Consist.shtml
+++ b/manual/3-0_DecoderPro/Comp_Consist.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Comp_FMap.shtml
+++ b/manual/3-0_DecoderPro/Comp_FMap.shtml
@@ -18,7 +18,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Comp_FunctionLabel.shtml
+++ b/manual/3-0_DecoderPro/Comp_FunctionLabel.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Comp_GlobalCVs.shtml
+++ b/manual/3-0_DecoderPro/Comp_GlobalCVs.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Comp_LightFX.shtml
+++ b/manual/3-0_DecoderPro/Comp_LightFX.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Comp_ManfSpecific.shtml
+++ b/manual/3-0_DecoderPro/Comp_ManfSpecific.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Comp_Motor.shtml
+++ b/manual/3-0_DecoderPro/Comp_Motor.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Comprehensive Programmer</h1>

--- a/manual/3-0_DecoderPro/Comp_PrintData.shtml
+++ b/manual/3-0_DecoderPro/Comp_PrintData.shtml
@@ -20,7 +20,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Comprehensive Programmer</h1>

--- a/manual/3-0_DecoderPro/Comp_PrintData_a.shtml
+++ b/manual/3-0_DecoderPro/Comp_PrintData_a.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1><a name="Top"><img src="images/Comp_09a_PrintData.png" alt="Comprehensive Programmer - Advanced Features"  border=5 height=494 width=382 hspace="20"></a></h1>

--- a/manual/3-0_DecoderPro/Comp_PrintData_b.shtml
+++ b/manual/3-0_DecoderPro/Comp_PrintData_b.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1><a name="Top"><img src="images/Comp_09b_PrintData.png" alt="Comprehensive Programmer - Advanced Features"  border=5 height=494 width=382 hspace="20"></a></h1>

--- a/manual/3-0_DecoderPro/Comp_PrintData_c.shtml
+++ b/manual/3-0_DecoderPro/Comp_PrintData_c.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
     <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Comp_Setup_Roster.shtml
+++ b/manual/3-0_DecoderPro/Comp_Setup_Roster.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
   <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Comp_SoundFX.shtml
+++ b/manual/3-0_DecoderPro/Comp_SoundFX.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Comp_SoundLevels.shtml
+++ b/manual/3-0_DecoderPro/Comp_SoundLevels.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Comp_Speed.shtml
+++ b/manual/3-0_DecoderPro/Comp_Speed.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Comp_Speed_Talble.shtml
+++ b/manual/3-0_DecoderPro/Comp_Speed_Talble.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Dcode_Format.shtml
+++ b/manual/3-0_DecoderPro/Dcode_Format.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Dcode_Start.shtml
+++ b/manual/3-0_DecoderPro/Dcode_Start.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Dcode_Submit.shtml
+++ b/manual/3-0_DecoderPro/Dcode_Submit.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Dcode_Testing.shtml
+++ b/manual/3-0_DecoderPro/Dcode_Testing.shtml
@@ -19,7 +19,7 @@ Decoder Definition
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Decoder Definition</h1>

--- a/manual/3-0_DecoderPro/Error.shtml
+++ b/manual/3-0_DecoderPro/Error.shtml
@@ -19,7 +19,7 @@ Error Messages
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Error Messages</h1>

--- a/manual/3-0_DecoderPro/Installing_JMRI.shtml
+++ b/manual/3-0_DecoderPro/Installing_JMRI.shtml
@@ -13,7 +13,7 @@
 </head>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Main_CMRI.shtml
+++ b/manual/3-0_DecoderPro/Main_CMRI.shtml
@@ -17,7 +17,7 @@ CMRI Menu
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-0_DecoderPro/Main_ConsistControl.shtml
+++ b/manual/3-0_DecoderPro/Main_ConsistControl.shtml
@@ -19,7 +19,7 @@ Tool Menu
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Tool Menu </h1>

--- a/manual/3-0_DecoderPro/Main_Debug.shtml
+++ b/manual/3-0_DecoderPro/Main_Debug.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Main_EasyDCC.shtml
+++ b/manual/3-0_DecoderPro/Main_EasyDCC.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Main_Edit.shtml
+++ b/manual/3-0_DecoderPro/Main_Edit.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Main_FastClockSetup.shtml
+++ b/manual/3-0_DecoderPro/Main_FastClockSetup.shtml
@@ -19,7 +19,7 @@ Tool Menu
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Tool Menu</h1>

--- a/manual/3-0_DecoderPro/Main_File.shtml
+++ b/manual/3-0_DecoderPro/Main_File.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Main_GrapeVine.shtml
+++ b/manual/3-0_DecoderPro/Main_GrapeVine.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-0_DecoderPro/Main_Help.shtml
+++ b/manual/3-0_DecoderPro/Main_Help.shtml
@@ -15,7 +15,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Main_LocoNet.shtml
+++ b/manual/3-0_DecoderPro/Main_LocoNet.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Main_Main.shtml
+++ b/manual/3-0_DecoderPro/Main_Main.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Main_Menu.shtml
+++ b/manual/3-0_DecoderPro/Main_Menu.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Main_Monitor_Window.shtml
+++ b/manual/3-0_DecoderPro/Main_Monitor_Window.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-0_DecoderPro/Main_NCE.shtml
+++ b/manual/3-0_DecoderPro/Main_NCE.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Main_OakTreeSystems.shtml
+++ b/manual/3-0_DecoderPro/Main_OakTreeSystems.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-0_DecoderPro/Main_Operations.shtml
+++ b/manual/3-0_DecoderPro/Main_Operations.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Main_PRICOM.shtml
+++ b/manual/3-0_DecoderPro/Main_PRICOM.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Debug Menu</h1>

--- a/manual/3-0_DecoderPro/Main_Panels.shtml
+++ b/manual/3-0_DecoderPro/Main_Panels.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Main_Powerline.shtml
+++ b/manual/3-0_DecoderPro/Main_Powerline.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-0_DecoderPro/Main_QSI.shtml
+++ b/manual/3-0_DecoderPro/Main_QSI.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-0_DecoderPro/Main_RPS.shtml
+++ b/manual/3-0_DecoderPro/Main_RPS.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-0_DecoderPro/Main_Roster.shtml
+++ b/manual/3-0_DecoderPro/Main_Roster.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Main_RosterGroup.shtml
+++ b/manual/3-0_DecoderPro/Main_RosterGroup.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Main_Roster_DP3.shtml
+++ b/manual/3-0_DecoderPro/Main_Roster_DP3.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Main Window</h1>

--- a/manual/3-0_DecoderPro/Main_SECSI.shtml
+++ b/manual/3-0_DecoderPro/Main_SECSI.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-0_DecoderPro/Main_SPROG.shtml
+++ b/manual/3-0_DecoderPro/Main_SPROG.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-0_DecoderPro/Main_Speedometer.shtml
+++ b/manual/3-0_DecoderPro/Main_Speedometer.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Tool Menu</h1>

--- a/manual/3-0_DecoderPro/Main_Speeometer.shtml
+++ b/manual/3-0_DecoderPro/Main_Speeometer.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Main_TMCC.shtml
+++ b/manual/3-0_DecoderPro/Main_TMCC.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-0_DecoderPro/Main_Throttle.shtml
+++ b/manual/3-0_DecoderPro/Main_Throttle.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Main_Tool.shtml
+++ b/manual/3-0_DecoderPro/Main_Tool.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Main_TurnoutControl.shtml
+++ b/manual/3-0_DecoderPro/Main_TurnoutControl.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Main_VSD.shtml
+++ b/manual/3-0_DecoderPro/Main_VSD.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Debug Menu</h1>

--- a/manual/3-0_DecoderPro/Main_Window.shtml
+++ b/manual/3-0_DecoderPro/Main_Window.shtml
@@ -18,7 +18,7 @@ DecoderPro&reg; Main Window
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-0_DecoderPro/Main_XpressNet.shtml
+++ b/manual/3-0_DecoderPro/Main_XpressNet.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-0_DecoderPro/Main_Zimo.shtml
+++ b/manual/3-0_DecoderPro/Main_Zimo.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-0_DecoderPro/Main_acela.shtml
+++ b/manual/3-0_DecoderPro/Main_acela.shtml
@@ -18,7 +18,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-0_DecoderPro/Main_lightControl.shtml
+++ b/manual/3-0_DecoderPro/Main_lightControl.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Tool Menu</h1>

--- a/manual/3-0_DecoderPro/Main_wangrow.shtml
+++ b/manual/3-0_DecoderPro/Main_wangrow.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-0_DecoderPro/Multi_Decoder_Control.shtml
+++ b/manual/3-0_DecoderPro/Multi_Decoder_Control.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window<
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-0_DecoderPro/Programmer_Multi_Decoder.shtml
+++ b/manual/3-0_DecoderPro/Programmer_Multi_Decoder.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-0_DecoderPro/Programmer_OpsMode.shtml
+++ b/manual/3-0_DecoderPro/Programmer_OpsMode.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <div align="center"><a name="Top"></a>

--- a/manual/3-0_DecoderPro/Programmer_ServiceMode.shtml
+++ b/manual/3-0_DecoderPro/Programmer_ServiceMode.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Programming Modes</h1>

--- a/manual/3-0_DecoderPro/Programmer_Setup.shtml
+++ b/manual/3-0_DecoderPro/Programmer_Setup.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Using DecoderPro&reg;</h1>

--- a/manual/3-0_DecoderPro/Programmer_SingleCV.shtml
+++ b/manual/3-0_DecoderPro/Programmer_SingleCV.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Programmer_Start.shtml
+++ b/manual/3-0_DecoderPro/Programmer_Start.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <div align="center"><a name="Top"></a>

--- a/manual/3-0_DecoderPro/Simple_Programmer.shtml
+++ b/manual/3-0_DecoderPro/Simple_Programmer.shtml
@@ -19,7 +19,7 @@ JMRI: Simple Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-0_DecoderPro/Start_DCC.shtml
+++ b/manual/3-0_DecoderPro/Start_DCC.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Start_DCC_Hardware.shtml
+++ b/manual/3-0_DecoderPro/Start_DCC_Hardware.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Start_DCC_Systems.shtml
+++ b/manual/3-0_DecoderPro/Start_DCC_Systems.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Start_DecoderPro.shtml
+++ b/manual/3-0_DecoderPro/Start_DecoderPro.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro/Start_Preferences.shtml
+++ b/manual/3-0_DecoderPro/Start_Preferences.shtml
@@ -25,7 +25,7 @@ function MM_jumpMenu(targ,selObj,restore){ //v3.0
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 <h1>Getting Started with DecoderPro&reg;</h1>
 <h1>How do I set up my preferences?</h1>

--- a/manual/3-0_DecoderPro/VSD_LocationsMgr.shtml
+++ b/manual/3-0_DecoderPro/VSD_LocationsMgr.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Debug Menu</h1>

--- a/manual/3-0_DecoderPro/VSD_Manager.shtml
+++ b/manual/3-0_DecoderPro/VSD_Manager.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Debug Menu</h1>

--- a/manual/3-0_DecoderPro/index.shtml
+++ b/manual/3-0_DecoderPro/index.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/Adv_FunctionLabel.shtml
+++ b/manual/3-0_DecoderPro3/Adv_FunctionLabel.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/Basic_BasicPane.shtml
+++ b/manual/3-0_DecoderPro3/Basic_BasicPane.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/Basic_Mode.shtml
+++ b/manual/3-0_DecoderPro3/Basic_Mode.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Programming Modes
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/Basic_Start.shtml
+++ b/manual/3-0_DecoderPro3/Basic_Start.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>The Basic Programmer</h1>

--- a/manual/3-0_DecoderPro3/Comp_Advanced.shtml
+++ b/manual/3-0_DecoderPro3/Comp_Advanced.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/Comp_Analog.shtml
+++ b/manual/3-0_DecoderPro3/Comp_Analog.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/Comp_Basic.shtml
+++ b/manual/3-0_DecoderPro3/Comp_Basic.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/Comp_Consist.shtml
+++ b/manual/3-0_DecoderPro3/Comp_Consist.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/Comp_FMap.shtml
+++ b/manual/3-0_DecoderPro3/Comp_FMap.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/Comp_GlobalCVs.shtml
+++ b/manual/3-0_DecoderPro3/Comp_GlobalCVs.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/Comp_LightFX.shtml
+++ b/manual/3-0_DecoderPro3/Comp_LightFX.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/Comp_ManfSpecific.shtml
+++ b/manual/3-0_DecoderPro3/Comp_ManfSpecific.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/Comp_Motor.shtml
+++ b/manual/3-0_DecoderPro3/Comp_Motor.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Comprehensive Programmer</h1>

--- a/manual/3-0_DecoderPro3/Comp_PrintData.shtml
+++ b/manual/3-0_DecoderPro3/Comp_PrintData.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Comprehensive Programmer</h1>

--- a/manual/3-0_DecoderPro3/Comp_PrintData_a.shtml
+++ b/manual/3-0_DecoderPro3/Comp_PrintData_a.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1><a name="Top"><img src="images/Comp_09a_PrintData.png" alt="Comprehensive Programmer - Advanced Features"  border=5 height=494 width=382 hspace="20"></a></h1>

--- a/manual/3-0_DecoderPro3/Comp_PrintData_b.shtml
+++ b/manual/3-0_DecoderPro3/Comp_PrintData_b.shtml
@@ -18,7 +18,7 @@ DecoderPro&reg; Comprehensive Programmer
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1><a name="Top"><img src="images/Comp_09b_PrintData.png" alt="Comprehensive Programmer - Advanced Features" border="5"

--- a/manual/3-0_DecoderPro3/Comp_PrintData_c.shtml
+++ b/manual/3-0_DecoderPro3/Comp_PrintData_c.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top">

--- a/manual/3-0_DecoderPro3/Comp_Setup_Roster.shtml
+++ b/manual/3-0_DecoderPro3/Comp_Setup_Roster.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
     <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/Comp_SoundLevels.shtml
+++ b/manual/3-0_DecoderPro3/Comp_SoundLevels.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/Comp_Speed.shtml
+++ b/manual/3-0_DecoderPro3/Comp_Speed.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/Comp_Speed_Talble.shtml
+++ b/manual/3-0_DecoderPro3/Comp_Speed_Talble.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/Error.shtml
+++ b/manual/3-0_DecoderPro3/Error.shtml
@@ -19,7 +19,7 @@ Error Messages
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Error Messages</h1>

--- a/manual/3-0_DecoderPro3/Installing_JMRI.shtml
+++ b/manual/3-0_DecoderPro3/Installing_JMRI.shtml
@@ -15,7 +15,7 @@
 </head>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/Main_CMRI.shtml
+++ b/manual/3-0_DecoderPro3/Main_CMRI.shtml
@@ -20,7 +20,7 @@ CMRI Menu
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-0_DecoderPro3/Main_EasyDCC.shtml
+++ b/manual/3-0_DecoderPro3/Main_EasyDCC.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/Main_FastClockSetup.shtml
+++ b/manual/3-0_DecoderPro3/Main_FastClockSetup.shtml
@@ -19,7 +19,7 @@ Tool Menu
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Tool Menu</h1>

--- a/manual/3-0_DecoderPro3/Main_GrapeVine.shtml
+++ b/manual/3-0_DecoderPro3/Main_GrapeVine.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-0_DecoderPro3/Main_LocoNet.shtml
+++ b/manual/3-0_DecoderPro3/Main_LocoNet.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/Main_Monitor_Window.shtml
+++ b/manual/3-0_DecoderPro3/Main_Monitor_Window.shtml
@@ -18,7 +18,7 @@ DecoderPro&reg; Main Window
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-0_DecoderPro3/Main_NCE.shtml
+++ b/manual/3-0_DecoderPro3/Main_NCE.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/Main_OakTreeSystems.shtml
+++ b/manual/3-0_DecoderPro3/Main_OakTreeSystems.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-0_DecoderPro3/Main_PRICOM.shtml
+++ b/manual/3-0_DecoderPro3/Main_PRICOM.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Debug Menu</h1>

--- a/manual/3-0_DecoderPro3/Main_Powerline.shtml
+++ b/manual/3-0_DecoderPro3/Main_Powerline.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-0_DecoderPro3/Main_QSI.shtml
+++ b/manual/3-0_DecoderPro3/Main_QSI.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-0_DecoderPro3/Main_RPS.shtml
+++ b/manual/3-0_DecoderPro3/Main_RPS.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-0_DecoderPro3/Main_SECSI.shtml
+++ b/manual/3-0_DecoderPro3/Main_SECSI.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-0_DecoderPro3/Main_SPROG.shtml
+++ b/manual/3-0_DecoderPro3/Main_SPROG.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-0_DecoderPro3/Main_TMCC.shtml
+++ b/manual/3-0_DecoderPro3/Main_TMCC.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-0_DecoderPro3/Main_XpressNet.shtml
+++ b/manual/3-0_DecoderPro3/Main_XpressNet.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-0_DecoderPro3/Main_Zimo.shtml
+++ b/manual/3-0_DecoderPro3/Main_Zimo.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-0_DecoderPro3/Main_acela.shtml
+++ b/manual/3-0_DecoderPro3/Main_acela.shtml
@@ -18,7 +18,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-0_DecoderPro3/Main_lightControl.shtml
+++ b/manual/3-0_DecoderPro3/Main_lightControl.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Tool Menu</h1>

--- a/manual/3-0_DecoderPro3/Main_wangrow.shtml
+++ b/manual/3-0_DecoderPro3/Main_wangrow.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-0_DecoderPro3/Programmer_Multi_Decoder.shtml
+++ b/manual/3-0_DecoderPro3/Programmer_Multi_Decoder.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Main Window</h1>

--- a/manual/3-0_DecoderPro3/Programmer_OpsMode.shtml
+++ b/manual/3-0_DecoderPro3/Programmer_OpsMode.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <div align="center"><a name="Top"></a>

--- a/manual/3-0_DecoderPro3/Programmer_ServiceMode.shtml
+++ b/manual/3-0_DecoderPro3/Programmer_ServiceMode.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Programming Modes</h1>

--- a/manual/3-0_DecoderPro3/Programmer_Setup.shtml
+++ b/manual/3-0_DecoderPro3/Programmer_Setup.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Using DecoderPro3&reg;</h1>

--- a/manual/3-0_DecoderPro3/Programmer_SingleCV.shtml
+++ b/manual/3-0_DecoderPro3/Programmer_SingleCV.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/RosterMedia.shtml
+++ b/manual/3-0_DecoderPro3/RosterMedia.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/Start_DCC.shtml
+++ b/manual/3-0_DecoderPro3/Start_DCC.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/Start_DCC_Hardware.shtml
+++ b/manual/3-0_DecoderPro3/Start_DCC_Hardware.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/Start_DCC_Systems.shtml
+++ b/manual/3-0_DecoderPro3/Start_DCC_Systems.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/Start_DecoderPro.shtml
+++ b/manual/3-0_DecoderPro3/Start_DecoderPro.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/Start_DecoderPro_New.shtml
+++ b/manual/3-0_DecoderPro3/Start_DecoderPro_New.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/Start_Preferences.shtml
+++ b/manual/3-0_DecoderPro3/Start_Preferences.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 <h1>Getting Started with DecoderPro3&reg;</h1>
 <h1>How do I set up my preferences?</h1>

--- a/manual/3-0_DecoderPro3/Throttle.shtml
+++ b/manual/3-0_DecoderPro3/Throttle.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/dp3_Main_ConsistControl.shtml
+++ b/manual/3-0_DecoderPro3/dp3_Main_ConsistControl.shtml
@@ -19,7 +19,7 @@ Tool Menu
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Main Window</h1>

--- a/manual/3-0_DecoderPro3/dp3_Main_Main.shtml
+++ b/manual/3-0_DecoderPro3/dp3_Main_Main.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/dp3_Main_Speedometer.shtml
+++ b/manual/3-0_DecoderPro3/dp3_Main_Speedometer.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Main Window</h1>

--- a/manual/3-0_DecoderPro3/dp3_Main_Throttle.shtml
+++ b/manual/3-0_DecoderPro3/dp3_Main_Throttle.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/dp3_Main_Throttle_FrameProperties.shtml
+++ b/manual/3-0_DecoderPro3/dp3_Main_Throttle_FrameProperties.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/dp3_Main_Throttle_List.shtml
+++ b/manual/3-0_DecoderPro3/dp3_Main_Throttle_List.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/dp3_Main_Throttle_addressPanel.shtml
+++ b/manual/3-0_DecoderPro3/dp3_Main_Throttle_addressPanel.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/dp3_Main_Throttle_controlPanel.shtml
+++ b/manual/3-0_DecoderPro3/dp3_Main_Throttle_controlPanel.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/dp3_Main_Throttle_functionPanel.shtml
+++ b/manual/3-0_DecoderPro3/dp3_Main_Throttle_functionPanel.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/dp3_Main_Throttle_menubar.shtml
+++ b/manual/3-0_DecoderPro3/dp3_Main_Throttle_menubar.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/dp3_Main_Throttle_toolbar.shtml
+++ b/manual/3-0_DecoderPro3/dp3_Main_Throttle_toolbar.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/dp3_Main_TurnoutControl.shtml
+++ b/manual/3-0_DecoderPro3/dp3_Main_TurnoutControl.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/dp3_Main_file_print_entry.shtml
+++ b/manual/3-0_DecoderPro3/dp3_Main_file_print_entry.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/dp3_decoderInfo.shtml
+++ b/manual/3-0_DecoderPro3/dp3_decoderInfo.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Main Window</h1>

--- a/manual/3-0_DecoderPro3/dp3_menubar.shtml
+++ b/manual/3-0_DecoderPro3/dp3_menubar.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/dp3_rosterTable.shtml
+++ b/manual/3-0_DecoderPro3/dp3_rosterTable.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Main Window</h1>

--- a/manual/3-0_DecoderPro3/dp3_settings_rosterGroups.shtml
+++ b/manual/3-0_DecoderPro3/dp3_settings_rosterGroups.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_DecoderPro3/dp3_toobar.shtml
+++ b/manual/3-0_DecoderPro3/dp3_toobar.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Main Window</h1>

--- a/manual/3-0_DecoderPro3/index.shtml
+++ b/manual/3-0_DecoderPro3/index.shtml
@@ -14,7 +14,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Installing_JMRI.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Installing_JMRI.shtml
@@ -15,7 +15,7 @@
 </head>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Main_Main.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Main_Main.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Main_Menu.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Main_Menu.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Main_Tool.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Main_Tool.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Ops_AddCars.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Ops_AddCars.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Ops_AddEngine.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Ops_AddEngine.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Ops_AddInterchange.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Ops_AddInterchange.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Ops_AddRoutes.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Ops_AddRoutes.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Ops_AddSiding.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Ops_AddSiding.shtml
@@ -18,7 +18,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Ops_AddStaging.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Ops_AddStaging.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Ops_AddTrain.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Ops_AddTrain.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Ops_AddTrainBuildOptions.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Ops_AddTrainBuildOptions.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Ops_AddYard.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Ops_AddYard.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Ops_BuildReportPreveiw.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Ops_BuildReportPreveiw.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Ops_BuildReportPrint.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Ops_BuildReportPrint.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Ops_CarAttributes.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Ops_CarAttributes.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Ops_Cars.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Ops_Cars.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Ops_EditTrain.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Ops_EditTrain.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Ops_EngineAttributes.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Ops_EngineAttributes.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Ops_Engines.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Ops_Engines.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Ops_ImportCarsFile.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Ops_ImportCarsFile.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Ops_ImportEngines.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Ops_ImportEngines.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Ops_Locations.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Ops_Locations.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Ops_Locations_Modify_Trains.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Ops_Locations_Modify_Trains.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Ops_Locations_byCar.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Ops_Locations_byCar.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Ops_Locations_setCars.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Ops_Locations_setCars.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Ops_ManifestPreview.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Ops_ManifestPreview.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Ops_ManifestPrint.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Ops_ManifestPrint.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Ops_PrintOptions.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Ops_PrintOptions.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Ops_Routes.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Ops_Routes.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Ops_RoutesEdit.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Ops_RoutesEdit.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Ops_Settings.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Ops_Settings.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Ops_Start.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Ops_Start.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Ops_Trains.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Ops_Trains.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Using JMRI&reg; to Operate Trains</h1>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Ops_TrainsBuild.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Ops_TrainsBuild.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Using JMRI&reg; to Operate Trains</h1>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Ops_TrainsModify.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Ops_TrainsModify.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Using JMRI&reg; to Operate Trains</h1>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Ops_Trains_BuildOptions.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Ops_Trains_BuildOptions.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Ops_Trains_Timetable.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Ops_Trains_Timetable.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Using JMRI&reg; to Operate Trains</h1>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Ops_TripThruOperations.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Ops_TripThruOperations.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Ops_schedule.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Ops_schedule.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Using JMRI&reg; to Operate Trains</h1>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Start_DCC.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Start_DCC.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Start_DCC_Hardware.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Start_DCC_Hardware.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Start_DCC_Systems.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Start_DCC_Systems.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Start_DecoderPro.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Start_DecoderPro.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-0_JMRI_OPS_UsersGuide/Start_Preferences.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/Start_Preferences.shtml
@@ -25,7 +25,7 @@ function MM_jumpMenu(targ,selObj,restore){ //v3.0
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 <h1>Getting Started with DecoderPro&reg;</h1>
 <h1>How do I set up my preferences?</h1>

--- a/manual/3-0_JMRI_OPS_UsersGuide/index.shtml
+++ b/manual/3-0_JMRI_OPS_UsersGuide/index.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 
 <div id="mainContent">
 

--- a/manual/3-2_DecoderPro/Adv_FunctionLabel.shtml
+++ b/manual/3-2_DecoderPro/Adv_FunctionLabel.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Adv_RosterMedia.shtml
+++ b/manual/3-2_DecoderPro/Adv_RosterMedia.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Adv_start.shtml
+++ b/manual/3-2_DecoderPro/Adv_start.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
   <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Basic_BasicPane.shtml
+++ b/manual/3-2_DecoderPro/Basic_BasicPane.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Basic_Mode.shtml
+++ b/manual/3-2_DecoderPro/Basic_Mode.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Programming Modes
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Basic_Programming.shtml
+++ b/manual/3-2_DecoderPro/Basic_Programming.shtml
@@ -19,7 +19,7 @@ Using DecoderPro&reg;
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Using DecoderPro&reg;</h1>

--- a/manual/3-2_DecoderPro/Basic_Start.shtml
+++ b/manual/3-2_DecoderPro/Basic_Start.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>The Basic Programmer</h1>

--- a/manual/3-2_DecoderPro/Comp_Advanced.shtml
+++ b/manual/3-2_DecoderPro/Comp_Advanced.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Comp_Analog.shtml
+++ b/manual/3-2_DecoderPro/Comp_Analog.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Comp_Basic.shtml
+++ b/manual/3-2_DecoderPro/Comp_Basic.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Comp_Consist.shtml
+++ b/manual/3-2_DecoderPro/Comp_Consist.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Comp_FMap.shtml
+++ b/manual/3-2_DecoderPro/Comp_FMap.shtml
@@ -18,7 +18,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Comp_FunctionLabel.shtml
+++ b/manual/3-2_DecoderPro/Comp_FunctionLabel.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Comp_GlobalCVs.shtml
+++ b/manual/3-2_DecoderPro/Comp_GlobalCVs.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Comp_LightFX.shtml
+++ b/manual/3-2_DecoderPro/Comp_LightFX.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Comp_ManfSpecific.shtml
+++ b/manual/3-2_DecoderPro/Comp_ManfSpecific.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Comp_Motor.shtml
+++ b/manual/3-2_DecoderPro/Comp_Motor.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Comprehensive Programmer</h1>

--- a/manual/3-2_DecoderPro/Comp_PrintData.shtml
+++ b/manual/3-2_DecoderPro/Comp_PrintData.shtml
@@ -20,7 +20,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Comprehensive Programmer</h1>

--- a/manual/3-2_DecoderPro/Comp_PrintData_a.shtml
+++ b/manual/3-2_DecoderPro/Comp_PrintData_a.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1><a name="Top"><img src="images/Comp_09a_PrintData.png" alt="Comprehensive Programmer - Advanced Features"  border=5 height=494 width=382 hspace="20"></a></h1>

--- a/manual/3-2_DecoderPro/Comp_PrintData_b.shtml
+++ b/manual/3-2_DecoderPro/Comp_PrintData_b.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1><a name="Top"><img src="images/Comp_09b_PrintData.png" alt="Comprehensive Programmer - Advanced Features"  border=5 height=494 width=382 hspace="20"></a></h1>

--- a/manual/3-2_DecoderPro/Comp_PrintData_c.shtml
+++ b/manual/3-2_DecoderPro/Comp_PrintData_c.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Comp_Setup_Roster.shtml
+++ b/manual/3-2_DecoderPro/Comp_Setup_Roster.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
   <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Comp_SoundFX.shtml
+++ b/manual/3-2_DecoderPro/Comp_SoundFX.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Comp_SoundLevels.shtml
+++ b/manual/3-2_DecoderPro/Comp_SoundLevels.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Comp_Speed.shtml
+++ b/manual/3-2_DecoderPro/Comp_Speed.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Comp_Speed_Talble.shtml
+++ b/manual/3-2_DecoderPro/Comp_Speed_Talble.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Dcode_Format.shtml
+++ b/manual/3-2_DecoderPro/Dcode_Format.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Dcode_Start.shtml
+++ b/manual/3-2_DecoderPro/Dcode_Start.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Dcode_Submit.shtml
+++ b/manual/3-2_DecoderPro/Dcode_Submit.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Dcode_Testing.shtml
+++ b/manual/3-2_DecoderPro/Dcode_Testing.shtml
@@ -19,7 +19,7 @@ Decoder Definition
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Decoder Definition</h1>

--- a/manual/3-2_DecoderPro/Error.shtml
+++ b/manual/3-2_DecoderPro/Error.shtml
@@ -19,7 +19,7 @@ Error Messages
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Error Messages</h1>

--- a/manual/3-2_DecoderPro/Installing_JMRI.shtml
+++ b/manual/3-2_DecoderPro/Installing_JMRI.shtml
@@ -15,7 +15,7 @@
 </head>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Main_CMRI.shtml
+++ b/manual/3-2_DecoderPro/Main_CMRI.shtml
@@ -20,7 +20,7 @@ CMRI Menu
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-2_DecoderPro/Main_ConsistControl.shtml
+++ b/manual/3-2_DecoderPro/Main_ConsistControl.shtml
@@ -19,7 +19,7 @@ Tool Menu
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Tool Menu </h1>

--- a/manual/3-2_DecoderPro/Main_Debug.shtml
+++ b/manual/3-2_DecoderPro/Main_Debug.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Main_EasyDCC.shtml
+++ b/manual/3-2_DecoderPro/Main_EasyDCC.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Main_Edit.shtml
+++ b/manual/3-2_DecoderPro/Main_Edit.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Main_FastClockSetup.shtml
+++ b/manual/3-2_DecoderPro/Main_FastClockSetup.shtml
@@ -19,7 +19,7 @@ Tool Menu
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Tool Menu</h1>

--- a/manual/3-2_DecoderPro/Main_File.shtml
+++ b/manual/3-2_DecoderPro/Main_File.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Main_GrapeVine.shtml
+++ b/manual/3-2_DecoderPro/Main_GrapeVine.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-2_DecoderPro/Main_Help.shtml
+++ b/manual/3-2_DecoderPro/Main_Help.shtml
@@ -17,7 +17,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Main_LocoNet.shtml
+++ b/manual/3-2_DecoderPro/Main_LocoNet.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Main_Main.shtml
+++ b/manual/3-2_DecoderPro/Main_Main.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Main_Menu.shtml
+++ b/manual/3-2_DecoderPro/Main_Menu.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Main_Monitor_Window.shtml
+++ b/manual/3-2_DecoderPro/Main_Monitor_Window.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-2_DecoderPro/Main_NCE.shtml
+++ b/manual/3-2_DecoderPro/Main_NCE.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Main_OakTreeSystems.shtml
+++ b/manual/3-2_DecoderPro/Main_OakTreeSystems.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-2_DecoderPro/Main_PRICOM.shtml
+++ b/manual/3-2_DecoderPro/Main_PRICOM.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Debug Menu</h1>

--- a/manual/3-2_DecoderPro/Main_Panels.shtml
+++ b/manual/3-2_DecoderPro/Main_Panels.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Main_Powerline.shtml
+++ b/manual/3-2_DecoderPro/Main_Powerline.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-2_DecoderPro/Main_QSI.shtml
+++ b/manual/3-2_DecoderPro/Main_QSI.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-2_DecoderPro/Main_RPS.shtml
+++ b/manual/3-2_DecoderPro/Main_RPS.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-2_DecoderPro/Main_Roster.shtml
+++ b/manual/3-2_DecoderPro/Main_Roster.shtml
@@ -15,7 +15,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Main_RosterGroup.shtml
+++ b/manual/3-2_DecoderPro/Main_RosterGroup.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Main_SECSI.shtml
+++ b/manual/3-2_DecoderPro/Main_SECSI.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-2_DecoderPro/Main_SPROG.shtml
+++ b/manual/3-2_DecoderPro/Main_SPROG.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-2_DecoderPro/Main_Speedometer.shtml
+++ b/manual/3-2_DecoderPro/Main_Speedometer.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Tool Menu</h1>

--- a/manual/3-2_DecoderPro/Main_Speeometer.shtml
+++ b/manual/3-2_DecoderPro/Main_Speeometer.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Main_TMCC.shtml
+++ b/manual/3-2_DecoderPro/Main_TMCC.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-2_DecoderPro/Main_Throttle.shtml
+++ b/manual/3-2_DecoderPro/Main_Throttle.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Main_Tool.shtml
+++ b/manual/3-2_DecoderPro/Main_Tool.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Main_TurnoutControl.shtml
+++ b/manual/3-2_DecoderPro/Main_TurnoutControl.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Main_VSD.shtml
+++ b/manual/3-2_DecoderPro/Main_VSD.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Debug Menu</h1>

--- a/manual/3-2_DecoderPro/Main_Window.shtml
+++ b/manual/3-2_DecoderPro/Main_Window.shtml
@@ -18,7 +18,7 @@ DecoderPro&reg; Main Window
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-2_DecoderPro/Main_XpressNet.shtml
+++ b/manual/3-2_DecoderPro/Main_XpressNet.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-2_DecoderPro/Main_Zimo.shtml
+++ b/manual/3-2_DecoderPro/Main_Zimo.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-2_DecoderPro/Main_acela.shtml
+++ b/manual/3-2_DecoderPro/Main_acela.shtml
@@ -18,7 +18,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-2_DecoderPro/Main_lightControl.shtml
+++ b/manual/3-2_DecoderPro/Main_lightControl.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Tool Menu</h1>

--- a/manual/3-2_DecoderPro/Main_wangrow.shtml
+++ b/manual/3-2_DecoderPro/Main_wangrow.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-2_DecoderPro/Multi_Decoder_Control.shtml
+++ b/manual/3-2_DecoderPro/Multi_Decoder_Control.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window<
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-2_DecoderPro/Programmer_Multi_Decoder.shtml
+++ b/manual/3-2_DecoderPro/Programmer_Multi_Decoder.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-2_DecoderPro/Programmer_OpsMode.shtml
+++ b/manual/3-2_DecoderPro/Programmer_OpsMode.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <div align="center"><a name="Top"></a>

--- a/manual/3-2_DecoderPro/Programmer_ServiceMode.shtml
+++ b/manual/3-2_DecoderPro/Programmer_ServiceMode.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Programming Modes</h1>

--- a/manual/3-2_DecoderPro/Programmer_Setup.shtml
+++ b/manual/3-2_DecoderPro/Programmer_Setup.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Using DecoderPro&reg;</h1>

--- a/manual/3-2_DecoderPro/Programmer_SingleCV.shtml
+++ b/manual/3-2_DecoderPro/Programmer_SingleCV.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Programmer_Start.shtml
+++ b/manual/3-2_DecoderPro/Programmer_Start.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <div align="center"><a name="Top"></a>

--- a/manual/3-2_DecoderPro/Simple_Programmer.shtml
+++ b/manual/3-2_DecoderPro/Simple_Programmer.shtml
@@ -19,7 +19,7 @@ JMRI: Simple Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-2_DecoderPro/Start_DCC.shtml
+++ b/manual/3-2_DecoderPro/Start_DCC.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Start_DCC_Hardware.shtml
+++ b/manual/3-2_DecoderPro/Start_DCC_Hardware.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Start_DCC_Systems.shtml
+++ b/manual/3-2_DecoderPro/Start_DCC_Systems.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Start_DecoderPro.shtml
+++ b/manual/3-2_DecoderPro/Start_DecoderPro.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro/Start_Preferences.shtml
+++ b/manual/3-2_DecoderPro/Start_Preferences.shtml
@@ -25,7 +25,7 @@ function MM_jumpMenu(targ,selObj,restore){ //v3.0
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 <h1>Getting Started with DecoderPro&reg;</h1>
 <h1>How do I set up my preferences?</h1>

--- a/manual/3-2_DecoderPro/VSD_LocationsMgr.shtml
+++ b/manual/3-2_DecoderPro/VSD_LocationsMgr.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Debug Menu</h1>

--- a/manual/3-2_DecoderPro/VSD_Manager.shtml
+++ b/manual/3-2_DecoderPro/VSD_Manager.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Debug Menu</h1>

--- a/manual/3-2_DecoderPro/dp3Roster.shtml
+++ b/manual/3-2_DecoderPro/dp3Roster.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro Roster Menu</h1>

--- a/manual/3-2_DecoderPro/index.shtml
+++ b/manual/3-2_DecoderPro/index.shtml
@@ -10,7 +10,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/Adv_FunctionLabel.shtml
+++ b/manual/3-2_DecoderPro3/Adv_FunctionLabel.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/Basic_BasicPane.shtml
+++ b/manual/3-2_DecoderPro3/Basic_BasicPane.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/Basic_Mode.shtml
+++ b/manual/3-2_DecoderPro3/Basic_Mode.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Programming Modes
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/Basic_Start.shtml
+++ b/manual/3-2_DecoderPro3/Basic_Start.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>The Basic Programmer</h1>

--- a/manual/3-2_DecoderPro3/Comp_Advanced.shtml
+++ b/manual/3-2_DecoderPro3/Comp_Advanced.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/Comp_Analog.shtml
+++ b/manual/3-2_DecoderPro3/Comp_Analog.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/Comp_Basic.shtml
+++ b/manual/3-2_DecoderPro3/Comp_Basic.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/Comp_Consist.shtml
+++ b/manual/3-2_DecoderPro3/Comp_Consist.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/Comp_FMap.shtml
+++ b/manual/3-2_DecoderPro3/Comp_FMap.shtml
@@ -18,7 +18,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/Comp_GlobalCVs.shtml
+++ b/manual/3-2_DecoderPro3/Comp_GlobalCVs.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/Comp_LightFX.shtml
+++ b/manual/3-2_DecoderPro3/Comp_LightFX.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/Comp_ManfSpecific.shtml
+++ b/manual/3-2_DecoderPro3/Comp_ManfSpecific.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/Comp_Motor.shtml
+++ b/manual/3-2_DecoderPro3/Comp_Motor.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Comprehensive Programmer</h1>

--- a/manual/3-2_DecoderPro3/Comp_PrintData.shtml
+++ b/manual/3-2_DecoderPro3/Comp_PrintData.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Comprehensive Programmer</h1>

--- a/manual/3-2_DecoderPro3/Comp_PrintData_a.shtml
+++ b/manual/3-2_DecoderPro3/Comp_PrintData_a.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1><a name="Top"><img src="images/Comp_09a_PrintData.png" alt="Comprehensive Programmer - Advanced Features"  border=5 height=494 width=382 hspace="20"></a></h1>

--- a/manual/3-2_DecoderPro3/Comp_PrintData_b.shtml
+++ b/manual/3-2_DecoderPro3/Comp_PrintData_b.shtml
@@ -18,7 +18,7 @@ DecoderPro&reg; Comprehensive Programmer
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1><a name="Top"><img src="images/Comp_09b_PrintData.png" alt="Comprehensive Programmer - Advanced Features"  border=5 height=494 width=382 hspace="20"></a></h1>

--- a/manual/3-2_DecoderPro3/Comp_PrintData_c.shtml
+++ b/manual/3-2_DecoderPro3/Comp_PrintData_c.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/Comp_Setup_Roster.shtml
+++ b/manual/3-2_DecoderPro3/Comp_Setup_Roster.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
     <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/Comp_SoundLevels.shtml
+++ b/manual/3-2_DecoderPro3/Comp_SoundLevels.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/Comp_Speed.shtml
+++ b/manual/3-2_DecoderPro3/Comp_Speed.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/Comp_Speed_Talble.shtml
+++ b/manual/3-2_DecoderPro3/Comp_Speed_Talble.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/Error.shtml
+++ b/manual/3-2_DecoderPro3/Error.shtml
@@ -19,7 +19,7 @@ Error Messages
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Error Messages</h1>

--- a/manual/3-2_DecoderPro3/Installing_JMRI.shtml
+++ b/manual/3-2_DecoderPro3/Installing_JMRI.shtml
@@ -15,7 +15,7 @@
 </head>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/Main_CMRI.shtml
+++ b/manual/3-2_DecoderPro3/Main_CMRI.shtml
@@ -20,7 +20,7 @@ CMRI Menu
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-2_DecoderPro3/Main_EasyDCC.shtml
+++ b/manual/3-2_DecoderPro3/Main_EasyDCC.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/Main_FastClockSetup.shtml
+++ b/manual/3-2_DecoderPro3/Main_FastClockSetup.shtml
@@ -19,7 +19,7 @@ Tool Menu
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Tool Menu</h1>

--- a/manual/3-2_DecoderPro3/Main_GrapeVine.shtml
+++ b/manual/3-2_DecoderPro3/Main_GrapeVine.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-2_DecoderPro3/Main_LocoNet.shtml
+++ b/manual/3-2_DecoderPro3/Main_LocoNet.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/Main_Monitor_Window.shtml
+++ b/manual/3-2_DecoderPro3/Main_Monitor_Window.shtml
@@ -18,7 +18,7 @@ DecoderPro&reg; Main Window
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-2_DecoderPro3/Main_NCE.shtml
+++ b/manual/3-2_DecoderPro3/Main_NCE.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/Main_OakTreeSystems.shtml
+++ b/manual/3-2_DecoderPro3/Main_OakTreeSystems.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-2_DecoderPro3/Main_PRICOM.shtml
+++ b/manual/3-2_DecoderPro3/Main_PRICOM.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Debug Menu</h1>

--- a/manual/3-2_DecoderPro3/Main_Powerline.shtml
+++ b/manual/3-2_DecoderPro3/Main_Powerline.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-2_DecoderPro3/Main_QSI.shtml
+++ b/manual/3-2_DecoderPro3/Main_QSI.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-2_DecoderPro3/Main_RPS.shtml
+++ b/manual/3-2_DecoderPro3/Main_RPS.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-2_DecoderPro3/Main_SECSI.shtml
+++ b/manual/3-2_DecoderPro3/Main_SECSI.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-2_DecoderPro3/Main_SPROG.shtml
+++ b/manual/3-2_DecoderPro3/Main_SPROG.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-2_DecoderPro3/Main_Speedo.shtml
+++ b/manual/3-2_DecoderPro3/Main_Speedo.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-2_DecoderPro3/Main_TMCC.shtml
+++ b/manual/3-2_DecoderPro3/Main_TMCC.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-2_DecoderPro3/Main_XpressNet.shtml
+++ b/manual/3-2_DecoderPro3/Main_XpressNet.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-2_DecoderPro3/Main_Zimo.shtml
+++ b/manual/3-2_DecoderPro3/Main_Zimo.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-2_DecoderPro3/Main_acela.shtml
+++ b/manual/3-2_DecoderPro3/Main_acela.shtml
@@ -18,7 +18,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-2_DecoderPro3/Main_lightControl.shtml
+++ b/manual/3-2_DecoderPro3/Main_lightControl.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Tool Menu</h1>

--- a/manual/3-2_DecoderPro3/Main_wangrow.shtml
+++ b/manual/3-2_DecoderPro3/Main_wangrow.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-2_DecoderPro3/Programmer_OpsMode.shtml
+++ b/manual/3-2_DecoderPro3/Programmer_OpsMode.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <div align="center"><a name="Top"></a>

--- a/manual/3-2_DecoderPro3/Programmer_ServiceMode.shtml
+++ b/manual/3-2_DecoderPro3/Programmer_ServiceMode.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Programming Modes</h1>

--- a/manual/3-2_DecoderPro3/Programmer_Setup.shtml
+++ b/manual/3-2_DecoderPro3/Programmer_Setup.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Using DecoderPro3&reg;</h1>

--- a/manual/3-2_DecoderPro3/Programmer_SingleCV.shtml
+++ b/manual/3-2_DecoderPro3/Programmer_SingleCV.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/RosterMedia.shtml
+++ b/manual/3-2_DecoderPro3/RosterMedia.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/Start_DCC.shtml
+++ b/manual/3-2_DecoderPro3/Start_DCC.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/Start_DCC_Hardware.shtml
+++ b/manual/3-2_DecoderPro3/Start_DCC_Hardware.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/Start_DCC_Systems.shtml
+++ b/manual/3-2_DecoderPro3/Start_DCC_Systems.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/Start_DecoderPro.shtml
+++ b/manual/3-2_DecoderPro3/Start_DecoderPro.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/Start_DecoderPro_New.shtml
+++ b/manual/3-2_DecoderPro3/Start_DecoderPro_New.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/Start_Preferences.shtml
+++ b/manual/3-2_DecoderPro3/Start_Preferences.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 <h1>Getting Started with DecoderPro3&reg;</h1>
 <h1>How do I set up my preferences?</h1>

--- a/manual/3-2_DecoderPro3/WiThrottle.shtml
+++ b/manual/3-2_DecoderPro3/WiThrottle.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/dp3_Main_ConsistControl.shtml
+++ b/manual/3-2_DecoderPro3/dp3_Main_ConsistControl.shtml
@@ -19,7 +19,7 @@ Tool Menu
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Main Window</h1>

--- a/manual/3-2_DecoderPro3/dp3_Main_Main.shtml
+++ b/manual/3-2_DecoderPro3/dp3_Main_Main.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/dp3_Main_Speedometer.shtml
+++ b/manual/3-2_DecoderPro3/dp3_Main_Speedometer.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Main Window</h1>

--- a/manual/3-2_DecoderPro3/dp3_Main_Throttle.shtml
+++ b/manual/3-2_DecoderPro3/dp3_Main_Throttle.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/dp3_Main_Throttle_FrameProperties.shtml
+++ b/manual/3-2_DecoderPro3/dp3_Main_Throttle_FrameProperties.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/dp3_Main_Throttle_List.shtml
+++ b/manual/3-2_DecoderPro3/dp3_Main_Throttle_List.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/dp3_Main_Throttle_addressPanel.shtml
+++ b/manual/3-2_DecoderPro3/dp3_Main_Throttle_addressPanel.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/dp3_Main_Throttle_controlPanel.shtml
+++ b/manual/3-2_DecoderPro3/dp3_Main_Throttle_controlPanel.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/dp3_Main_Throttle_functionPanel.shtml
+++ b/manual/3-2_DecoderPro3/dp3_Main_Throttle_functionPanel.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/dp3_Main_Throttle_menubar.shtml
+++ b/manual/3-2_DecoderPro3/dp3_Main_Throttle_menubar.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/dp3_Main_Throttle_toolbar.shtml
+++ b/manual/3-2_DecoderPro3/dp3_Main_Throttle_toolbar.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/dp3_Main_TurnoutControl.shtml
+++ b/manual/3-2_DecoderPro3/dp3_Main_TurnoutControl.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/dp3_Main_file_print_entry.shtml
+++ b/manual/3-2_DecoderPro3/dp3_Main_file_print_entry.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/dp3_decoderInfo.shtml
+++ b/manual/3-2_DecoderPro3/dp3_decoderInfo.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Main Window</h1>

--- a/manual/3-2_DecoderPro3/dp3_menubar.shtml
+++ b/manual/3-2_DecoderPro3/dp3_menubar.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/dp3_rosterTable.shtml
+++ b/manual/3-2_DecoderPro3/dp3_rosterTable.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Main Window</h1>

--- a/manual/3-2_DecoderPro3/dp3_settings_rosterGroups.shtml
+++ b/manual/3-2_DecoderPro3/dp3_settings_rosterGroups.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_DecoderPro3/dp3_toobar.shtml
+++ b/manual/3-2_DecoderPro3/dp3_toobar.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Main Window</h1>

--- a/manual/3-2_DecoderPro3/index.shtml
+++ b/manual/3-2_DecoderPro3/index.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Installing_JMRI.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Installing_JMRI.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Main_Main.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Main_Main.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Main_Menu.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Main_Menu.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Main_Tool.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Main_Tool.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Ops_AddCars.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Ops_AddCars.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Ops_AddEngine.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Ops_AddEngine.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Ops_AddInterchange.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Ops_AddInterchange.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Ops_AddRoutes.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Ops_AddRoutes.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Ops_AddSiding.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Ops_AddSiding.shtml
@@ -18,7 +18,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Ops_AddStaging.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Ops_AddStaging.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Ops_AddTrain.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Ops_AddTrain.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Ops_AddTrainBuildOptions.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Ops_AddTrainBuildOptions.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Ops_AddYard.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Ops_AddYard.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Ops_BuildReportPreveiw.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Ops_BuildReportPreveiw.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Ops_BuildReportPrint.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Ops_BuildReportPrint.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Ops_CarAttributes.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Ops_CarAttributes.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Ops_Cars.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Ops_Cars.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Ops_EditTrain.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Ops_EditTrain.shtml
@@ -13,7 +13,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent"><a name="Top"></a>
 <h1>Using JMRI&reg; to Operate Trains</h1>
 <h1>Edit Train<br>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Ops_EngineAttributes.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Ops_EngineAttributes.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Ops_Engines.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Ops_Engines.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Ops_ImportCarsFile.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Ops_ImportCarsFile.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Ops_ImportEngines.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Ops_ImportEngines.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Ops_Locations.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Ops_Locations.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Ops_Locations_Modify_Trains.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Ops_Locations_Modify_Trains.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Ops_Locations_byCar.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Ops_Locations_byCar.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Ops_Locations_print-Preview_ByCarType.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Ops_Locations_print-Preview_ByCarType.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Ops_Locations_printByCarType.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Ops_Locations_printByCarType.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Ops_Locations_setCars.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Ops_Locations_setCars.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Ops_ManifestPreview.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Ops_ManifestPreview.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Ops_ManifestPrint.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Ops_ManifestPrint.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Ops_PrintOptions.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Ops_PrintOptions.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Ops_Routes.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Ops_Routes.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Ops_RoutesEdit.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Ops_RoutesEdit.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Ops_Settings.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Ops_Settings.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Ops_Start.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Ops_Start.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Ops_Trains.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Ops_Trains.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Using JMRI&reg; to Operate Trains</h1>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Ops_TrainsBuild.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Ops_TrainsBuild.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Using JMRI&reg; to Operate Trains</h1>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Ops_TrainsModify.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Ops_TrainsModify.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Using JMRI&reg; to Operate Trains</h1>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Ops_Trains_BuildOptions.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Ops_Trains_BuildOptions.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Ops_Trains_Timetable.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Ops_Trains_Timetable.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Using JMRI&reg; to Operate Trains</h1>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Ops_TripThruOperations.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Ops_TripThruOperations.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Ops_schedule.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Ops_schedule.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Using JMRI&reg; to Operate Trains</h1>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Start_DCC.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Start_DCC.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Start_DCC_Hardware.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Start_DCC_Hardware.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Start_DCC_Systems.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Start_DCC_Systems.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Start_DecoderPro.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Start_DecoderPro.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-2_JMRI_OPS_UsersGuide/Start_Preferences.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/Start_Preferences.shtml
@@ -18,7 +18,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 <h1>Getting Started with DecoderPro&reg;</h1>
 <h1>How do I set up my preferences?</h1>

--- a/manual/3-2_JMRI_OPS_UsersGuide/index.shtml
+++ b/manual/3-2_JMRI_OPS_UsersGuide/index.shtml
@@ -14,7 +14,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 
 <div id="mainContent">
 

--- a/manual/3-4_DecoderPro/Adv_FunctionLabel.shtml
+++ b/manual/3-4_DecoderPro/Adv_FunctionLabel.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Adv_RosterMedia.shtml
+++ b/manual/3-4_DecoderPro/Adv_RosterMedia.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Adv_start.shtml
+++ b/manual/3-4_DecoderPro/Adv_start.shtml
@@ -10,7 +10,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top">

--- a/manual/3-4_DecoderPro/Basic_BasicPane.shtml
+++ b/manual/3-4_DecoderPro/Basic_BasicPane.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Basic_Mode.shtml
+++ b/manual/3-4_DecoderPro/Basic_Mode.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Programming Modes
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Basic_Programming.shtml
+++ b/manual/3-4_DecoderPro/Basic_Programming.shtml
@@ -19,7 +19,7 @@ Using DecoderPro&reg;
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Using DecoderPro&reg;</h1>

--- a/manual/3-4_DecoderPro/Basic_Start.shtml
+++ b/manual/3-4_DecoderPro/Basic_Start.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>The Basic Programmer</h1>

--- a/manual/3-4_DecoderPro/Comp_Advanced.shtml
+++ b/manual/3-4_DecoderPro/Comp_Advanced.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Comp_Analog.shtml
+++ b/manual/3-4_DecoderPro/Comp_Analog.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Comp_Basic.shtml
+++ b/manual/3-4_DecoderPro/Comp_Basic.shtml
@@ -13,7 +13,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Comp_Consist.shtml
+++ b/manual/3-4_DecoderPro/Comp_Consist.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Comp_FMap.shtml
+++ b/manual/3-4_DecoderPro/Comp_FMap.shtml
@@ -18,7 +18,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Comp_FunctionLabel.shtml
+++ b/manual/3-4_DecoderPro/Comp_FunctionLabel.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Comp_GlobalCVs.shtml
+++ b/manual/3-4_DecoderPro/Comp_GlobalCVs.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Comp_LightFX.shtml
+++ b/manual/3-4_DecoderPro/Comp_LightFX.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Comp_ManfSpecific.shtml
+++ b/manual/3-4_DecoderPro/Comp_ManfSpecific.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Comp_Motor.shtml
+++ b/manual/3-4_DecoderPro/Comp_Motor.shtml
@@ -15,7 +15,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Comprehensive Programmer</h1>

--- a/manual/3-4_DecoderPro/Comp_PrintData.shtml
+++ b/manual/3-4_DecoderPro/Comp_PrintData.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Comprehensive Programmer</h1>

--- a/manual/3-4_DecoderPro/Comp_PrintData_a.shtml
+++ b/manual/3-4_DecoderPro/Comp_PrintData_a.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1><a name="Top"><img src="images/Comp_09a_PrintData.png" alt="Comprehensive Programmer - Advanced Features"  border=5 height=494 width=382 hspace="20"></a></h1>

--- a/manual/3-4_DecoderPro/Comp_PrintData_b.shtml
+++ b/manual/3-4_DecoderPro/Comp_PrintData_b.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1><a name="Top"><img src="images/Comp_09b_PrintData.png" alt="Comprehensive Programmer - Advanced Features"  border=5 height=494 width=382 hspace="20"></a></h1>

--- a/manual/3-4_DecoderPro/Comp_PrintData_c.shtml
+++ b/manual/3-4_DecoderPro/Comp_PrintData_c.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
     <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Comp_Setup_Roster.shtml
+++ b/manual/3-4_DecoderPro/Comp_Setup_Roster.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top">

--- a/manual/3-4_DecoderPro/Comp_SoundFX.shtml
+++ b/manual/3-4_DecoderPro/Comp_SoundFX.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Comp_SoundLevels.shtml
+++ b/manual/3-4_DecoderPro/Comp_SoundLevels.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Comp_Speed.shtml
+++ b/manual/3-4_DecoderPro/Comp_Speed.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Comp_Speed_Talble.shtml
+++ b/manual/3-4_DecoderPro/Comp_Speed_Talble.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Dcode_Format.shtml
+++ b/manual/3-4_DecoderPro/Dcode_Format.shtml
@@ -10,7 +10,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Dcode_Start.shtml
+++ b/manual/3-4_DecoderPro/Dcode_Start.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Dcode_Submit.shtml
+++ b/manual/3-4_DecoderPro/Dcode_Submit.shtml
@@ -10,7 +10,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Dcode_Testing.shtml
+++ b/manual/3-4_DecoderPro/Dcode_Testing.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Decoder Definition</h1>

--- a/manual/3-4_DecoderPro/Error.shtml
+++ b/manual/3-4_DecoderPro/Error.shtml
@@ -19,7 +19,7 @@ Error Messages
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Error Messages</h1>

--- a/manual/3-4_DecoderPro/Installing_JMRI.shtml
+++ b/manual/3-4_DecoderPro/Installing_JMRI.shtml
@@ -15,7 +15,7 @@
 </head>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Main_CMRI.shtml
+++ b/manual/3-4_DecoderPro/Main_CMRI.shtml
@@ -20,7 +20,7 @@ CMRI Menu
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-4_DecoderPro/Main_ConsistControl.shtml
+++ b/manual/3-4_DecoderPro/Main_ConsistControl.shtml
@@ -19,7 +19,7 @@ Tool Menu
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Tool Menu </h1>

--- a/manual/3-4_DecoderPro/Main_Debug.shtml
+++ b/manual/3-4_DecoderPro/Main_Debug.shtml
@@ -15,7 +15,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Main_EasyDCC.shtml
+++ b/manual/3-4_DecoderPro/Main_EasyDCC.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Main_Edit.shtml
+++ b/manual/3-4_DecoderPro/Main_Edit.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Main_FastClockSetup.shtml
+++ b/manual/3-4_DecoderPro/Main_FastClockSetup.shtml
@@ -19,7 +19,7 @@ Tool Menu
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Tool Menu</h1>

--- a/manual/3-4_DecoderPro/Main_File.shtml
+++ b/manual/3-4_DecoderPro/Main_File.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Main_GrapeVine.shtml
+++ b/manual/3-4_DecoderPro/Main_GrapeVine.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-4_DecoderPro/Main_Help.shtml
+++ b/manual/3-4_DecoderPro/Main_Help.shtml
@@ -12,7 +12,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Main_LocoNet.shtml
+++ b/manual/3-4_DecoderPro/Main_LocoNet.shtml
@@ -13,7 +13,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Main_Main.shtml
+++ b/manual/3-4_DecoderPro/Main_Main.shtml
@@ -15,7 +15,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Main_Menu.shtml
+++ b/manual/3-4_DecoderPro/Main_Menu.shtml
@@ -13,7 +13,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent"><a name="Top"></a>
 <h1>DecoderPro&reg; Main Window</h1>
 <h1>Menu Overview</h1>

--- a/manual/3-4_DecoderPro/Main_Monitor_Window.shtml
+++ b/manual/3-4_DecoderPro/Main_Monitor_Window.shtml
@@ -12,7 +12,7 @@
 </head>
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 <h1>DecoderPro&reg; Main Window</h1>
 <h1>Communications Monitor Window</h1>

--- a/manual/3-4_DecoderPro/Main_NCE.shtml
+++ b/manual/3-4_DecoderPro/Main_NCE.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Main_OakTreeSystems.shtml
+++ b/manual/3-4_DecoderPro/Main_OakTreeSystems.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-4_DecoderPro/Main_PRICOM.shtml
+++ b/manual/3-4_DecoderPro/Main_PRICOM.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Debug Menu</h1>

--- a/manual/3-4_DecoderPro/Main_Panels.shtml
+++ b/manual/3-4_DecoderPro/Main_Panels.shtml
@@ -13,7 +13,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Main_Powerline.shtml
+++ b/manual/3-4_DecoderPro/Main_Powerline.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-4_DecoderPro/Main_QSI.shtml
+++ b/manual/3-4_DecoderPro/Main_QSI.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-4_DecoderPro/Main_RPS.shtml
+++ b/manual/3-4_DecoderPro/Main_RPS.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-4_DecoderPro/Main_Roster.shtml
+++ b/manual/3-4_DecoderPro/Main_Roster.shtml
@@ -14,7 +14,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Main_RosterGroup.shtml
+++ b/manual/3-4_DecoderPro/Main_RosterGroup.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Main_SECSI.shtml
+++ b/manual/3-4_DecoderPro/Main_SECSI.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-4_DecoderPro/Main_SPROG.shtml
+++ b/manual/3-4_DecoderPro/Main_SPROG.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-4_DecoderPro/Main_Speedometer.shtml
+++ b/manual/3-4_DecoderPro/Main_Speedometer.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Tool Menu</h1>

--- a/manual/3-4_DecoderPro/Main_Speeometer.shtml
+++ b/manual/3-4_DecoderPro/Main_Speeometer.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Main_TMCC.shtml
+++ b/manual/3-4_DecoderPro/Main_TMCC.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-4_DecoderPro/Main_Throttle.shtml
+++ b/manual/3-4_DecoderPro/Main_Throttle.shtml
@@ -9,7 +9,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Main_Throttle_FrameProperties.shtml
+++ b/manual/3-4_DecoderPro/Main_Throttle_FrameProperties.shtml
@@ -13,7 +13,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Main_Throttle_List.shtml
+++ b/manual/3-4_DecoderPro/Main_Throttle_List.shtml
@@ -13,7 +13,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Main_Throttle_addressPanel.shtml
+++ b/manual/3-4_DecoderPro/Main_Throttle_addressPanel.shtml
@@ -13,7 +13,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Main_Throttle_controlPanel.shtml
+++ b/manual/3-4_DecoderPro/Main_Throttle_controlPanel.shtml
@@ -9,7 +9,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Main_Throttle_functionPanel.shtml
+++ b/manual/3-4_DecoderPro/Main_Throttle_functionPanel.shtml
@@ -13,7 +13,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Main_Throttle_menubar.shtml
+++ b/manual/3-4_DecoderPro/Main_Throttle_menubar.shtml
@@ -13,7 +13,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Main_Throttle_toolbar.shtml
+++ b/manual/3-4_DecoderPro/Main_Throttle_toolbar.shtml
@@ -13,7 +13,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Main_Tool.shtml
+++ b/manual/3-4_DecoderPro/Main_Tool.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Main_TurnoutControl.shtml
+++ b/manual/3-4_DecoderPro/Main_TurnoutControl.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Main_VSD.shtml
+++ b/manual/3-4_DecoderPro/Main_VSD.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Debug Menu</h1>

--- a/manual/3-4_DecoderPro/Main_Window.shtml
+++ b/manual/3-4_DecoderPro/Main_Window.shtml
@@ -18,7 +18,7 @@ DecoderPro&reg; Main Window
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-4_DecoderPro/Main_XpressNet.shtml
+++ b/manual/3-4_DecoderPro/Main_XpressNet.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-4_DecoderPro/Main_Zimo.shtml
+++ b/manual/3-4_DecoderPro/Main_Zimo.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-4_DecoderPro/Main_acela.shtml
+++ b/manual/3-4_DecoderPro/Main_acela.shtml
@@ -18,7 +18,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-4_DecoderPro/Main_lightControl.shtml
+++ b/manual/3-4_DecoderPro/Main_lightControl.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Tool Menu</h1>

--- a/manual/3-4_DecoderPro/Main_wangrow.shtml
+++ b/manual/3-4_DecoderPro/Main_wangrow.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-4_DecoderPro/Multi_Decoder_Control.shtml
+++ b/manual/3-4_DecoderPro/Multi_Decoder_Control.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window<
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-4_DecoderPro/Programmer_Multi_Decoder.shtml
+++ b/manual/3-4_DecoderPro/Programmer_Multi_Decoder.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-4_DecoderPro/Programmer_OpsMode.shtml
+++ b/manual/3-4_DecoderPro/Programmer_OpsMode.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <div align="center"><a name="Top"></a>

--- a/manual/3-4_DecoderPro/Programmer_ServiceMode.shtml
+++ b/manual/3-4_DecoderPro/Programmer_ServiceMode.shtml
@@ -13,7 +13,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Programming Modes</h1>

--- a/manual/3-4_DecoderPro/Programmer_Setup.shtml
+++ b/manual/3-4_DecoderPro/Programmer_Setup.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Using DecoderPro&reg;</h1>

--- a/manual/3-4_DecoderPro/Programmer_SingleCV.shtml
+++ b/manual/3-4_DecoderPro/Programmer_SingleCV.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Programmer_Start.shtml
+++ b/manual/3-4_DecoderPro/Programmer_Start.shtml
@@ -15,7 +15,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <div align="center"><a name="Top"></a>

--- a/manual/3-4_DecoderPro/Start_DCC.shtml
+++ b/manual/3-4_DecoderPro/Start_DCC.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Start_DCC_Hardware.shtml
+++ b/manual/3-4_DecoderPro/Start_DCC_Hardware.shtml
@@ -15,7 +15,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Start_DCC_Systems.shtml
+++ b/manual/3-4_DecoderPro/Start_DCC_Systems.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Start_DecoderPro.shtml
+++ b/manual/3-4_DecoderPro/Start_DecoderPro.shtml
@@ -15,7 +15,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro/Start_Preferences.shtml
+++ b/manual/3-4_DecoderPro/Start_Preferences.shtml
@@ -25,7 +25,7 @@ function MM_jumpMenu(targ,selObj,restore){ //v3.0
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 <h1>Getting Started with DecoderPro&reg;</h1>
 <h1>How do I set up my preferences?</h1>

--- a/manual/3-4_DecoderPro/VSD_LocationsMgr.shtml
+++ b/manual/3-4_DecoderPro/VSD_LocationsMgr.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Debug Menu</h1>

--- a/manual/3-4_DecoderPro/VSD_Manager.shtml
+++ b/manual/3-4_DecoderPro/VSD_Manager.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Debug Menu</h1>

--- a/manual/3-4_DecoderPro/WiThrottle.shtml
+++ b/manual/3-4_DecoderPro/WiThrottle.shtml
@@ -14,7 +14,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
     <a name="Top"></a>

--- a/manual/3-4_DecoderPro/dp3Roster.shtml
+++ b/manual/3-4_DecoderPro/dp3Roster.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro Roster Menu</h1>

--- a/manual/3-4_DecoderPro/index.shtml
+++ b/manual/3-4_DecoderPro/index.shtml
@@ -13,7 +13,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/Adv_FunctionLabel.shtml
+++ b/manual/3-4_DecoderPro3/Adv_FunctionLabel.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/Basic_BasicPane.shtml
+++ b/manual/3-4_DecoderPro3/Basic_BasicPane.shtml
@@ -13,7 +13,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/Basic_Mode.shtml
+++ b/manual/3-4_DecoderPro3/Basic_Mode.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Programming Modes
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/Basic_Start.shtml
+++ b/manual/3-4_DecoderPro3/Basic_Start.shtml
@@ -15,7 +15,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>The Basic Programmer</h1>

--- a/manual/3-4_DecoderPro3/Comp_Advanced.shtml
+++ b/manual/3-4_DecoderPro3/Comp_Advanced.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/Comp_Analog.shtml
+++ b/manual/3-4_DecoderPro3/Comp_Analog.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/Comp_Basic.shtml
+++ b/manual/3-4_DecoderPro3/Comp_Basic.shtml
@@ -14,7 +14,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/Comp_Consist.shtml
+++ b/manual/3-4_DecoderPro3/Comp_Consist.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/Comp_FMap.shtml
+++ b/manual/3-4_DecoderPro3/Comp_FMap.shtml
@@ -18,7 +18,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/Comp_GlobalCVs.shtml
+++ b/manual/3-4_DecoderPro3/Comp_GlobalCVs.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/Comp_LightFX.shtml
+++ b/manual/3-4_DecoderPro3/Comp_LightFX.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/Comp_ManfSpecific.shtml
+++ b/manual/3-4_DecoderPro3/Comp_ManfSpecific.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/Comp_Motor.shtml
+++ b/manual/3-4_DecoderPro3/Comp_Motor.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Comprehensive Programmer</h1>

--- a/manual/3-4_DecoderPro3/Comp_PrintData.shtml
+++ b/manual/3-4_DecoderPro3/Comp_PrintData.shtml
@@ -20,7 +20,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Comprehensive Programmer</h1>

--- a/manual/3-4_DecoderPro3/Comp_PrintData_a.shtml
+++ b/manual/3-4_DecoderPro3/Comp_PrintData_a.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1><a name="Top"><img src="images/Comp_09a_PrintData.png" alt="Comprehensive Programmer - Advanced Features"  border=5 height=494 width=382 hspace="20"></a></h1>

--- a/manual/3-4_DecoderPro3/Comp_PrintData_b.shtml
+++ b/manual/3-4_DecoderPro3/Comp_PrintData_b.shtml
@@ -18,7 +18,7 @@ DecoderPro&reg; Comprehensive Programmer
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1><a name="Top"><img src="images/Comp_09b_PrintData.png" alt="Comprehensive Programmer - Advanced Features"  border=5 height=494 width=382 hspace="20"></a></h1>

--- a/manual/3-4_DecoderPro3/Comp_PrintData_c.shtml
+++ b/manual/3-4_DecoderPro3/Comp_PrintData_c.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
     <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/Comp_Setup_Roster.shtml
+++ b/manual/3-4_DecoderPro3/Comp_Setup_Roster.shtml
@@ -15,7 +15,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top">

--- a/manual/3-4_DecoderPro3/Comp_SoundLevels.shtml
+++ b/manual/3-4_DecoderPro3/Comp_SoundLevels.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/Comp_Speed.shtml
+++ b/manual/3-4_DecoderPro3/Comp_Speed.shtml
@@ -15,7 +15,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/Comp_Speed_Talble.shtml
+++ b/manual/3-4_DecoderPro3/Comp_Speed_Talble.shtml
@@ -13,7 +13,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/Error.shtml
+++ b/manual/3-4_DecoderPro3/Error.shtml
@@ -19,7 +19,7 @@ Error Messages
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Error Messages</h1>

--- a/manual/3-4_DecoderPro3/Installing_JMRI.shtml
+++ b/manual/3-4_DecoderPro3/Installing_JMRI.shtml
@@ -15,7 +15,7 @@
 </head>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/Main_CMRI.shtml
+++ b/manual/3-4_DecoderPro3/Main_CMRI.shtml
@@ -20,7 +20,7 @@ CMRI Menu
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-4_DecoderPro3/Main_EasyDCC.shtml
+++ b/manual/3-4_DecoderPro3/Main_EasyDCC.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/Main_FastClockSetup.shtml
+++ b/manual/3-4_DecoderPro3/Main_FastClockSetup.shtml
@@ -19,7 +19,7 @@ Tool Menu
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Tool Menu</h1>

--- a/manual/3-4_DecoderPro3/Main_GrapeVine.shtml
+++ b/manual/3-4_DecoderPro3/Main_GrapeVine.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-4_DecoderPro3/Main_LocoNet.shtml
+++ b/manual/3-4_DecoderPro3/Main_LocoNet.shtml
@@ -13,7 +13,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/Main_Monitor_Window.shtml
+++ b/manual/3-4_DecoderPro3/Main_Monitor_Window.shtml
@@ -13,7 +13,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 <h1>DecoderPro&reg; Main Window</h1>
 <h1>Communications Monitor Window</h1>

--- a/manual/3-4_DecoderPro3/Main_NCE.shtml
+++ b/manual/3-4_DecoderPro3/Main_NCE.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/Main_OakTreeSystems.shtml
+++ b/manual/3-4_DecoderPro3/Main_OakTreeSystems.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-4_DecoderPro3/Main_PRICOM.shtml
+++ b/manual/3-4_DecoderPro3/Main_PRICOM.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Debug Menu</h1>

--- a/manual/3-4_DecoderPro3/Main_Powerline.shtml
+++ b/manual/3-4_DecoderPro3/Main_Powerline.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-4_DecoderPro3/Main_QSI.shtml
+++ b/manual/3-4_DecoderPro3/Main_QSI.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-4_DecoderPro3/Main_RPS.shtml
+++ b/manual/3-4_DecoderPro3/Main_RPS.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-4_DecoderPro3/Main_SECSI.shtml
+++ b/manual/3-4_DecoderPro3/Main_SECSI.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-4_DecoderPro3/Main_SPROG.shtml
+++ b/manual/3-4_DecoderPro3/Main_SPROG.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-4_DecoderPro3/Main_Speedo.shtml
+++ b/manual/3-4_DecoderPro3/Main_Speedo.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-4_DecoderPro3/Main_TMCC.shtml
+++ b/manual/3-4_DecoderPro3/Main_TMCC.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-4_DecoderPro3/Main_XpressNet.shtml
+++ b/manual/3-4_DecoderPro3/Main_XpressNet.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-4_DecoderPro3/Main_Zimo.shtml
+++ b/manual/3-4_DecoderPro3/Main_Zimo.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-4_DecoderPro3/Main_acela.shtml
+++ b/manual/3-4_DecoderPro3/Main_acela.shtml
@@ -18,7 +18,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-4_DecoderPro3/Main_lightControl.shtml
+++ b/manual/3-4_DecoderPro3/Main_lightControl.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Tool Menu</h1>

--- a/manual/3-4_DecoderPro3/Main_wangrow.shtml
+++ b/manual/3-4_DecoderPro3/Main_wangrow.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-4_DecoderPro3/Programmer_OpsMode.shtml
+++ b/manual/3-4_DecoderPro3/Programmer_OpsMode.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <div align="center"><a name="Top"></a>

--- a/manual/3-4_DecoderPro3/Programmer_ServiceMode.shtml
+++ b/manual/3-4_DecoderPro3/Programmer_ServiceMode.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Programming Modes</h1>

--- a/manual/3-4_DecoderPro3/Programmer_Setup.shtml
+++ b/manual/3-4_DecoderPro3/Programmer_Setup.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Using DecoderPro3&reg;</h1>

--- a/manual/3-4_DecoderPro3/Programmer_SingleCV.shtml
+++ b/manual/3-4_DecoderPro3/Programmer_SingleCV.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/RosterMedia.shtml
+++ b/manual/3-4_DecoderPro3/RosterMedia.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/Start_DCC.shtml
+++ b/manual/3-4_DecoderPro3/Start_DCC.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/Start_DCC_Hardware.shtml
+++ b/manual/3-4_DecoderPro3/Start_DCC_Hardware.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/Start_DCC_Systems.shtml
+++ b/manual/3-4_DecoderPro3/Start_DCC_Systems.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/Start_DecoderPro.shtml
+++ b/manual/3-4_DecoderPro3/Start_DecoderPro.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/Start_DecoderPro_New.shtml
+++ b/manual/3-4_DecoderPro3/Start_DecoderPro_New.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/Start_Preferences.shtml
+++ b/manual/3-4_DecoderPro3/Start_Preferences.shtml
@@ -24,7 +24,7 @@ function MM_jumpMenu(targ,selObj,restore){ //v3.0
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 <h1>Getting Started with DecoderPro3&reg;</h1>
 <h1>How do I set up my preferences?</h1>

--- a/manual/3-4_DecoderPro3/WiThrottle.shtml
+++ b/manual/3-4_DecoderPro3/WiThrottle.shtml
@@ -15,7 +15,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/dp3_Main_ConsistControl.shtml
+++ b/manual/3-4_DecoderPro3/dp3_Main_ConsistControl.shtml
@@ -15,7 +15,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Main Window</h1>

--- a/manual/3-4_DecoderPro3/dp3_Main_Main.shtml
+++ b/manual/3-4_DecoderPro3/dp3_Main_Main.shtml
@@ -14,7 +14,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/dp3_Main_Speedometer.shtml
+++ b/manual/3-4_DecoderPro3/dp3_Main_Speedometer.shtml
@@ -15,7 +15,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Main Window</h1>

--- a/manual/3-4_DecoderPro3/dp3_Main_Throttle.shtml
+++ b/manual/3-4_DecoderPro3/dp3_Main_Throttle.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/dp3_Main_Throttle_FrameProperties.shtml
+++ b/manual/3-4_DecoderPro3/dp3_Main_Throttle_FrameProperties.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/dp3_Main_Throttle_List.shtml
+++ b/manual/3-4_DecoderPro3/dp3_Main_Throttle_List.shtml
@@ -13,7 +13,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/dp3_Main_Throttle_addressPanel.shtml
+++ b/manual/3-4_DecoderPro3/dp3_Main_Throttle_addressPanel.shtml
@@ -15,7 +15,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/dp3_Main_Throttle_controlPanel.shtml
+++ b/manual/3-4_DecoderPro3/dp3_Main_Throttle_controlPanel.shtml
@@ -15,7 +15,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/dp3_Main_Throttle_functionPanel.shtml
+++ b/manual/3-4_DecoderPro3/dp3_Main_Throttle_functionPanel.shtml
@@ -15,7 +15,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/dp3_Main_Throttle_menubar.shtml
+++ b/manual/3-4_DecoderPro3/dp3_Main_Throttle_menubar.shtml
@@ -15,7 +15,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/dp3_Main_Throttle_toolbar.shtml
+++ b/manual/3-4_DecoderPro3/dp3_Main_Throttle_toolbar.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/dp3_Main_TurnoutControl.shtml
+++ b/manual/3-4_DecoderPro3/dp3_Main_TurnoutControl.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/dp3_Main_file_print_entry.shtml
+++ b/manual/3-4_DecoderPro3/dp3_Main_file_print_entry.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/dp3_decoderInfo.shtml
+++ b/manual/3-4_DecoderPro3/dp3_decoderInfo.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Main Window</h1>

--- a/manual/3-4_DecoderPro3/dp3_menubar.shtml
+++ b/manual/3-4_DecoderPro3/dp3_menubar.shtml
@@ -15,7 +15,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/dp3_rosterTable.shtml
+++ b/manual/3-4_DecoderPro3/dp3_rosterTable.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Main Window</h1>

--- a/manual/3-4_DecoderPro3/dp3_settings_rosterGroups.shtml
+++ b/manual/3-4_DecoderPro3/dp3_settings_rosterGroups.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_DecoderPro3/dp3_toobar.shtml
+++ b/manual/3-4_DecoderPro3/dp3_toobar.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Main Window</h1>

--- a/manual/3-4_DecoderPro3/index.shtml
+++ b/manual/3-4_DecoderPro3/index.shtml
@@ -12,7 +12,7 @@
 </head>
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent"><a name="Top"></a>
 
 <h1>DecoderPro3&reg; Version 3.4</h1>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Installing_JMRI.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Installing_JMRI.shtml
@@ -15,7 +15,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 
 <div id="mainContent">
 

--- a/manual/3-4_JMRI_OPS_UsersGuide/Main_Main.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Main_Main.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Main_Menu.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Main_Menu.shtml
@@ -15,7 +15,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_AddCars.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_AddCars.shtml
@@ -15,7 +15,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_AddEngine.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_AddEngine.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_AddInterchange.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_AddInterchange.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_AddLocations.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_AddLocations.shtml
@@ -13,7 +13,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_AddRoutes.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_AddRoutes.shtml
@@ -14,7 +14,7 @@
 </head>
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_AddSiding.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_AddSiding.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_AddStaging.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_AddStaging.shtml
@@ -13,7 +13,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_AddTrain.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_AddTrain.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_AddTrainBuildOptions.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_AddTrainBuildOptions.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_AddYard.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_AddYard.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_BuildReportPreveiw.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_BuildReportPreveiw.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_BuildReportPrint.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_BuildReportPrint.shtml
@@ -13,7 +13,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_CarAttributes.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_CarAttributes.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_Cars.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_Cars.shtml
@@ -23,7 +23,7 @@
 <!-- /Style -->
 </head><body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent"><a name="Top"></a>
 <h1>Using JMRI&reg; to Operate Trains</h1>
 <h1>Operations Cars Window</h1>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_Cars_Menu.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_Cars_Menu.shtml
@@ -14,7 +14,7 @@
 </head>
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent"><a name="Top"></a>
 <h1>Using JMRI&reg; to Operate Trains</h1>
 <h1>Operations Cars Window Menu Bar<br>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_EditEngines.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_EditEngines.shtml
@@ -12,7 +12,7 @@
 </head>
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent"><a name="Top"></a>
 <h1>Using JMRI&reg; to Operate Trains</h1>
 <h1>Edit Locomotives</h1>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_EditLocation.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_EditLocation.shtml
@@ -9,7 +9,7 @@
 <link rel="home" title="Home" href="/"><!-- /Style --></head>
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent"><a name="Top"></a>
 <h1>Using JMRI&reg; to Operate Trains</h1>
 <h1>Operations Edit Location Window</h1>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_EditLocation_menu.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_EditLocation_menu.shtml
@@ -8,7 +8,7 @@
 <link rel="home" title="Home" href="/"><!-- /Style --></head>
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent"><a name="Top"></a>
 <h1>Using JMRI&reg; to Operate Trains</h1>
 <h1>Operations Edit Location Menu Bar</h1>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_EditLocation_track.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_EditLocation_track.shtml
@@ -13,7 +13,7 @@
 </head>
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent"><a name="Top"></a>
 <h1>Using JMRI&reg; to Operate Trains</h1>
 <h1>Operations Edit Location Track Window</h1>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_EditLocation_trackMenu.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_EditLocation_trackMenu.shtml
@@ -12,7 +12,7 @@
 </head>
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent"><a name="Top"></a>
 <h1>Using JMRI&reg; to Operate Trains</h1>
 <h1>Operations Locations Edit Track Menu Bar</h1>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_EditRoutes.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_EditRoutes.shtml
@@ -12,7 +12,7 @@
 </head>
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
     <a name="Top"></a>
 <h1>Using JMRI&reg; to Operate Trains</h1>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_EditTrain.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_EditTrain.shtml
@@ -10,7 +10,7 @@
 <link href="/" title="Home" rel="home"><!-- /Style --></head>
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent"><a name="Top"></a>
 <h1>Using JMRI&reg; to Operate Trains</h1>
 <h1>Edit Train<br>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_EngineAttributes.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_EngineAttributes.shtml
@@ -13,7 +13,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_Engines.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_Engines.shtml
@@ -11,7 +11,7 @@
 </head>
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent"><a name="Top"></a>
 <h1>Using JMRI&reg; to Operate Trains</h1>
 <h1>Operations Locomotive Window</h1>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_Engines_menu.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_Engines_menu.shtml
@@ -13,7 +13,7 @@
 </head>
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent"><a name="Top"></a>
 <h1>Using JMRI&reg; to Operate Trains</h1>
 <h1>Operations Locomotive Window Menu Bar</h1>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_ImportCarsFile.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_ImportCarsFile.shtml
@@ -13,7 +13,7 @@
 </head>
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent"><a name="Top"></a>
 <h1>Using JMRI&reg; to Operate Trains</h1>
 <h1>Importing Cars from a File</h1>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_ImportEngines_FromFiles.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_ImportEngines_FromFiles.shtml
@@ -13,7 +13,7 @@
 </head>
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent"><a name="Top"></a>
 <h1>Using JMRI&reg; to Operate Trains</h1>
 <h1>Import Locomotives from a File </h1>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_ImportEngines_FromRoster.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_ImportEngines_FromRoster.shtml
@@ -10,7 +10,7 @@
 <link rel="home" title="Home" href="/"><!-- /Style --></head>
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent"><a name="Top"></a>
 <h1>Using JMRI&reg; to Operate Trains</h1>
 <h1>Importing Locomotives from Roster </h1>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_Locations.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_Locations.shtml
@@ -12,7 +12,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_Locations_List.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_Locations_List.shtml
@@ -13,7 +13,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_Locations_Menu.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_Locations_Menu.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_Locations_Modify_Trains.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_Locations_Modify_Trains.shtml
@@ -12,7 +12,7 @@
 </head>
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_Locations_SwitchList.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_Locations_SwitchList.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_Locations_byCar.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_Locations_byCar.shtml
@@ -13,7 +13,7 @@
 </head>
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent"><a name="Top"></a>
 <h1>Using JMRI&reg; to Operate Trains</h1>
 <h1>Operations Modify Locations by Car Type Window</h1>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_Locations_print-Preview_ByCarType.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_Locations_print-Preview_ByCarType.shtml
@@ -14,7 +14,7 @@
 </head>
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent"><a name="Top"></a>
 <h1>Using JMRI&reg; to Operate Trains</h1>
 <h1>Print Preview: Locations Servicing Car Types Window</h1>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_Locations_printByCarType.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_Locations_printByCarType.shtml
@@ -13,7 +13,7 @@
 </head>
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent"><a name="Top"></a>
 <h1>Using JMRI&reg; to Operate Trains</h1>
 <h1>Print Locations Servicing Car Types Window</h1>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_Locations_setCars.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_Locations_setCars.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_ManifestPreview.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_ManifestPreview.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_ManifestPrint.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_ManifestPrint.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_PrintOptions.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_PrintOptions.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_Routes.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_Routes.shtml
@@ -15,7 +15,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_Routes_Menu.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_Routes_Menu.shtml
@@ -10,7 +10,7 @@
 <link rel="home" title="Home" href="/"><!-- /Style --></head>
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent"><a name="Top"></a>
 <h1>Using JMRI&reg; to Operate Trains</h1>
 <h1>Operations Routes Menu Bar</h1>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_SetEngines.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_SetEngines.shtml
@@ -13,7 +13,7 @@
 </head>
 <body>
 <!--#include virtual="/Header.shtml" -->BackB
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_Settings.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_Settings.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_Settings_Tools_Options.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_Settings_Tools_Options.shtml
@@ -13,7 +13,7 @@
 </head>
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent"><a name="Top"></a>
 
 <h1>Using JMRI&reg; to Operate Trains</h1>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_Settings_menubar.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_Settings_menubar.shtml
@@ -10,7 +10,7 @@
 <link rel="home" title="Home" href="/"><!-- /Style --></head>
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent"><a name="Top"></a>
 <h1>Using JMRI&reg; to Operate Trains</h1>
 <h1>Operations Settings Menu Bar</h1>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_Start.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_Start.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_Trains.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_Trains.shtml
@@ -13,7 +13,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Using JMRI&reg; to Operate Trains</h1>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_TrainsBuild.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_TrainsBuild.shtml
@@ -13,7 +13,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Using JMRI&reg; to Operate Trains</h1>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_TrainsModify.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_TrainsModify.shtml
@@ -15,7 +15,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Using JMRI&reg; to Operate Trains</h1>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_Trains_BuildOptions.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_Trains_BuildOptions.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_Trains_Menu.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_Trains_Menu.shtml
@@ -14,7 +14,7 @@
 </head>
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 <h1>Using JMRI&reg; to Operate Trains</h1>
 <h1>Operations Trains Window Menu Bar</h1>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_Trains_Timetable.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_Trains_Timetable.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Using JMRI&reg; to Operate Trains</h1>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_TripThruOperations.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_TripThruOperations.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Ops_schedule.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Ops_schedule.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Using JMRI&reg; to Operate Trains</h1>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Start_DCC.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Start_DCC.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Start_DCC_Hardware.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Start_DCC_Hardware.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Start_DCC_Systems.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Start_DCC_Systems.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Start_DecoderPro.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Start_DecoderPro.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-4_JMRI_OPS_UsersGuide/Start_Preferences.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/Start_Preferences.shtml
@@ -25,7 +25,7 @@ function MM_jumpMenu(targ,selObj,restore){ //v3.0
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 <h1>Getting Started with DecoderPro&reg;</h1>
 <h1>How do I set up my preferences?</h1>

--- a/manual/3-4_JMRI_OPS_UsersGuide/index.shtml
+++ b/manual/3-4_JMRI_OPS_UsersGuide/index.shtml
@@ -14,7 +14,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 
 <div id="mainContent"><a name="Top"></a>
 <h1>JMRI&reg; OperationsPro Manual</h1>

--- a/manual/3-6_DecoderPro/Adv_FunctionLabel.shtml
+++ b/manual/3-6_DecoderPro/Adv_FunctionLabel.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Adv_RosterMedia.shtml
+++ b/manual/3-6_DecoderPro/Adv_RosterMedia.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Adv_start.shtml
+++ b/manual/3-6_DecoderPro/Adv_start.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top">

--- a/manual/3-6_DecoderPro/Basic_BasicPane.shtml
+++ b/manual/3-6_DecoderPro/Basic_BasicPane.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Basic_Mode.shtml
+++ b/manual/3-6_DecoderPro/Basic_Mode.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Programming Modes
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Basic_Start.shtml
+++ b/manual/3-6_DecoderPro/Basic_Start.shtml
@@ -15,7 +15,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>The Basic Programmer</h1>

--- a/manual/3-6_DecoderPro/Comp_Advanced.shtml
+++ b/manual/3-6_DecoderPro/Comp_Advanced.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Comp_Analog.shtml
+++ b/manual/3-6_DecoderPro/Comp_Analog.shtml
@@ -15,7 +15,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Comp_Basic.shtml
+++ b/manual/3-6_DecoderPro/Comp_Basic.shtml
@@ -12,7 +12,7 @@
 <link rel="icon" href="/images/jmri.ico" type="image/png">
 <link rel="home" title="Home" href="/"><!-- /Style --></head><body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Comp_Consist.shtml
+++ b/manual/3-6_DecoderPro/Comp_Consist.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Comp_FMap.shtml
+++ b/manual/3-6_DecoderPro/Comp_FMap.shtml
@@ -15,7 +15,7 @@
 <link rel="home" title="Home" href="/"><!-- /Style --></head><body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Comp_FunctionLabel.shtml
+++ b/manual/3-6_DecoderPro/Comp_FunctionLabel.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Comp_GlobalCVs.shtml
+++ b/manual/3-6_DecoderPro/Comp_GlobalCVs.shtml
@@ -12,7 +12,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Comp_LightFX.shtml
+++ b/manual/3-6_DecoderPro/Comp_LightFX.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Comp_ManfSpecific.shtml
+++ b/manual/3-6_DecoderPro/Comp_ManfSpecific.shtml
@@ -14,7 +14,7 @@
 <link rel="home" title="Home" href="/"><!-- /Style --></head><body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Comp_Motor.shtml
+++ b/manual/3-6_DecoderPro/Comp_Motor.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Comprehensive Programmer</h1>

--- a/manual/3-6_DecoderPro/Comp_PrintData.shtml
+++ b/manual/3-6_DecoderPro/Comp_PrintData.shtml
@@ -15,7 +15,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Comprehensive Programmer</h1>

--- a/manual/3-6_DecoderPro/Comp_PrintData_a.shtml
+++ b/manual/3-6_DecoderPro/Comp_PrintData_a.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1><a name="Top"><img src="images/Comp_09a_PrintData.png" alt="Comprehensive Programmer - Advanced Features"  border=5 height=494 width=382 hspace="20"></a></h1>

--- a/manual/3-6_DecoderPro/Comp_PrintData_b.shtml
+++ b/manual/3-6_DecoderPro/Comp_PrintData_b.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1><a name="Top"><img src="images/Comp_09b_PrintData.png" alt="Comprehensive Programmer - Advanced Features"  border=5 height=494 width=382 hspace="20"></a></h1>

--- a/manual/3-6_DecoderPro/Comp_PrintData_c.shtml
+++ b/manual/3-6_DecoderPro/Comp_PrintData_c.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
     <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Comp_Setup_Roster.shtml
+++ b/manual/3-6_DecoderPro/Comp_Setup_Roster.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top">

--- a/manual/3-6_DecoderPro/Comp_SoundFX.shtml
+++ b/manual/3-6_DecoderPro/Comp_SoundFX.shtml
@@ -15,7 +15,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Comp_SoundLevels.shtml
+++ b/manual/3-6_DecoderPro/Comp_SoundLevels.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Comp_Speed.shtml
+++ b/manual/3-6_DecoderPro/Comp_Speed.shtml
@@ -15,7 +15,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Comp_Speed_Talble.shtml
+++ b/manual/3-6_DecoderPro/Comp_Speed_Talble.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Dcode_Format.shtml
+++ b/manual/3-6_DecoderPro/Dcode_Format.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Dcode_Start.shtml
+++ b/manual/3-6_DecoderPro/Dcode_Start.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Dcode_Submit.shtml
+++ b/manual/3-6_DecoderPro/Dcode_Submit.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Dcode_Testing.shtml
+++ b/manual/3-6_DecoderPro/Dcode_Testing.shtml
@@ -15,7 +15,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Decoder Definition</h1>

--- a/manual/3-6_DecoderPro/Error.shtml
+++ b/manual/3-6_DecoderPro/Error.shtml
@@ -19,7 +19,7 @@ Error Messages
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Error Messages</h1>

--- a/manual/3-6_DecoderPro/Installing_JMRI.shtml
+++ b/manual/3-6_DecoderPro/Installing_JMRI.shtml
@@ -15,7 +15,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Main_CMRI.shtml
+++ b/manual/3-6_DecoderPro/Main_CMRI.shtml
@@ -18,7 +18,7 @@ CMRI Menu
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-6_DecoderPro/Main_ConsistControl.shtml
+++ b/manual/3-6_DecoderPro/Main_ConsistControl.shtml
@@ -19,7 +19,7 @@ Tool Menu
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Tool Menu </h1>

--- a/manual/3-6_DecoderPro/Main_Debug.shtml
+++ b/manual/3-6_DecoderPro/Main_Debug.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Main_EasyDCC.shtml
+++ b/manual/3-6_DecoderPro/Main_EasyDCC.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Main_Edit.shtml
+++ b/manual/3-6_DecoderPro/Main_Edit.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Main_FastClockSetup.shtml
+++ b/manual/3-6_DecoderPro/Main_FastClockSetup.shtml
@@ -19,7 +19,7 @@ Tool Menu
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Tool Menu</h1>

--- a/manual/3-6_DecoderPro/Main_File.shtml
+++ b/manual/3-6_DecoderPro/Main_File.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Main_GrapeVine.shtml
+++ b/manual/3-6_DecoderPro/Main_GrapeVine.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-6_DecoderPro/Main_Help.shtml
+++ b/manual/3-6_DecoderPro/Main_Help.shtml
@@ -15,7 +15,7 @@
 </head>
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Main_LocoNet.shtml
+++ b/manual/3-6_DecoderPro/Main_LocoNet.shtml
@@ -13,7 +13,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Main_Main.shtml
+++ b/manual/3-6_DecoderPro/Main_Main.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Main_Menu.shtml
+++ b/manual/3-6_DecoderPro/Main_Menu.shtml
@@ -13,7 +13,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent"><a name="Top"></a>
 <h1>DecoderPro&reg; Main Window</h1>
 <h1>Menu Overview</h1>

--- a/manual/3-6_DecoderPro/Main_Monitor_Window.shtml
+++ b/manual/3-6_DecoderPro/Main_Monitor_Window.shtml
@@ -10,7 +10,7 @@
 <link rel="home" title="Home" href="/"><!-- /Style --></head>
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 <h1>DecoderPro&reg; Main Window</h1>
 <h1>Communications Monitor Window</h1>

--- a/manual/3-6_DecoderPro/Main_NCE.shtml
+++ b/manual/3-6_DecoderPro/Main_NCE.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Main_OakTreeSystems.shtml
+++ b/manual/3-6_DecoderPro/Main_OakTreeSystems.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-6_DecoderPro/Main_PRICOM.shtml
+++ b/manual/3-6_DecoderPro/Main_PRICOM.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Debug Menu</h1>

--- a/manual/3-6_DecoderPro/Main_Panels.shtml
+++ b/manual/3-6_DecoderPro/Main_Panels.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Main_Powerline.shtml
+++ b/manual/3-6_DecoderPro/Main_Powerline.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-6_DecoderPro/Main_QSI.shtml
+++ b/manual/3-6_DecoderPro/Main_QSI.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-6_DecoderPro/Main_RPS.shtml
+++ b/manual/3-6_DecoderPro/Main_RPS.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-6_DecoderPro/Main_Roster.shtml
+++ b/manual/3-6_DecoderPro/Main_Roster.shtml
@@ -13,7 +13,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Main_RosterGroup.shtml
+++ b/manual/3-6_DecoderPro/Main_RosterGroup.shtml
@@ -15,7 +15,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Main_SECSI.shtml
+++ b/manual/3-6_DecoderPro/Main_SECSI.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-6_DecoderPro/Main_SPROG.shtml
+++ b/manual/3-6_DecoderPro/Main_SPROG.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-6_DecoderPro/Main_Speedometer.shtml
+++ b/manual/3-6_DecoderPro/Main_Speedometer.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Tool Menu</h1>

--- a/manual/3-6_DecoderPro/Main_Speeometer.shtml
+++ b/manual/3-6_DecoderPro/Main_Speeometer.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Main_TMCC.shtml
+++ b/manual/3-6_DecoderPro/Main_TMCC.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-6_DecoderPro/Main_Throttle.shtml
+++ b/manual/3-6_DecoderPro/Main_Throttle.shtml
@@ -9,7 +9,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Main_Throttle_FrameProperties.shtml
+++ b/manual/3-6_DecoderPro/Main_Throttle_FrameProperties.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Main_Throttle_List.shtml
+++ b/manual/3-6_DecoderPro/Main_Throttle_List.shtml
@@ -13,7 +13,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Main_Throttle_addressPanel.shtml
+++ b/manual/3-6_DecoderPro/Main_Throttle_addressPanel.shtml
@@ -13,7 +13,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Main_Throttle_controlPanel.shtml
+++ b/manual/3-6_DecoderPro/Main_Throttle_controlPanel.shtml
@@ -13,7 +13,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Main_Throttle_functionPanel.shtml
+++ b/manual/3-6_DecoderPro/Main_Throttle_functionPanel.shtml
@@ -13,7 +13,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Main_Throttle_menubar.shtml
+++ b/manual/3-6_DecoderPro/Main_Throttle_menubar.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Main_Throttle_toolbar.shtml
+++ b/manual/3-6_DecoderPro/Main_Throttle_toolbar.shtml
@@ -13,7 +13,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Main_Tool.shtml
+++ b/manual/3-6_DecoderPro/Main_Tool.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Main_TurnoutControl.shtml
+++ b/manual/3-6_DecoderPro/Main_TurnoutControl.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Main_VSD.shtml
+++ b/manual/3-6_DecoderPro/Main_VSD.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Debug Menu</h1>

--- a/manual/3-6_DecoderPro/Main_Window.shtml
+++ b/manual/3-6_DecoderPro/Main_Window.shtml
@@ -18,7 +18,7 @@ DecoderPro&reg; Main Window
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-6_DecoderPro/Main_XpressNet.shtml
+++ b/manual/3-6_DecoderPro/Main_XpressNet.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-6_DecoderPro/Main_Zimo.shtml
+++ b/manual/3-6_DecoderPro/Main_Zimo.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-6_DecoderPro/Main_acela.shtml
+++ b/manual/3-6_DecoderPro/Main_acela.shtml
@@ -18,7 +18,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-6_DecoderPro/Main_lightControl.shtml
+++ b/manual/3-6_DecoderPro/Main_lightControl.shtml
@@ -18,7 +18,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Tool Menu</h1>

--- a/manual/3-6_DecoderPro/Main_wangrow.shtml
+++ b/manual/3-6_DecoderPro/Main_wangrow.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-6_DecoderPro/Multi_Decoder_Control.shtml
+++ b/manual/3-6_DecoderPro/Multi_Decoder_Control.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-6_DecoderPro/Programmer_Multi_Decoder.shtml
+++ b/manual/3-6_DecoderPro/Programmer_Multi_Decoder.shtml
@@ -19,7 +19,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-6_DecoderPro/Programmer_OpsMode.shtml
+++ b/manual/3-6_DecoderPro/Programmer_OpsMode.shtml
@@ -19,7 +19,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <div align="center"><a name="Top"></a>

--- a/manual/3-6_DecoderPro/Programmer_ServiceMode.shtml
+++ b/manual/3-6_DecoderPro/Programmer_ServiceMode.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Programming Modes</h1>

--- a/manual/3-6_DecoderPro/Programmer_Setup.shtml
+++ b/manual/3-6_DecoderPro/Programmer_Setup.shtml
@@ -18,7 +18,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Using DecoderPro&reg;</h1>

--- a/manual/3-6_DecoderPro/Programmer_SingleCV.shtml
+++ b/manual/3-6_DecoderPro/Programmer_SingleCV.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Programmer_Start.shtml
+++ b/manual/3-6_DecoderPro/Programmer_Start.shtml
@@ -15,7 +15,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <div align="center"><a name="Top"></a>

--- a/manual/3-6_DecoderPro/Start_DCC.shtml
+++ b/manual/3-6_DecoderPro/Start_DCC.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Start_DCC_Hardware.shtml
+++ b/manual/3-6_DecoderPro/Start_DCC_Hardware.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Start_DCC_Systems.shtml
+++ b/manual/3-6_DecoderPro/Start_DCC_Systems.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/Start_DecoderPro.shtml
+++ b/manual/3-6_DecoderPro/Start_DecoderPro.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro/VSD_LocationsMgr.shtml
+++ b/manual/3-6_DecoderPro/VSD_LocationsMgr.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Debug Menu</h1>

--- a/manual/3-6_DecoderPro/VSD_Manager.shtml
+++ b/manual/3-6_DecoderPro/VSD_Manager.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Debug Menu</h1>

--- a/manual/3-6_DecoderPro/WiThrottle.shtml
+++ b/manual/3-6_DecoderPro/WiThrottle.shtml
@@ -13,7 +13,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent"><a name="Top"></a>
 <h1>DecoderPro&reg;</h1>
 <h1>WiThrottle</h1>

--- a/manual/3-6_DecoderPro/dp3Roster.shtml
+++ b/manual/3-6_DecoderPro/dp3Roster.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro Roster Menu</h1>

--- a/manual/3-6_DecoderPro/index.shtml
+++ b/manual/3-6_DecoderPro/index.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/Adv_FunctionLabel.shtml
+++ b/manual/3-6_DecoderPro3/Adv_FunctionLabel.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/Basic_BasicPane.shtml
+++ b/manual/3-6_DecoderPro3/Basic_BasicPane.shtml
@@ -13,7 +13,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/Basic_Mode.shtml
+++ b/manual/3-6_DecoderPro3/Basic_Mode.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/Basic_Start.shtml
+++ b/manual/3-6_DecoderPro3/Basic_Start.shtml
@@ -10,7 +10,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>The Basic Programmer</h1>

--- a/manual/3-6_DecoderPro3/Comp_Advanced.shtml
+++ b/manual/3-6_DecoderPro3/Comp_Advanced.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/Comp_Analog.shtml
+++ b/manual/3-6_DecoderPro3/Comp_Analog.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/Comp_Basic.shtml
+++ b/manual/3-6_DecoderPro3/Comp_Basic.shtml
@@ -13,7 +13,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/Comp_Consist.shtml
+++ b/manual/3-6_DecoderPro3/Comp_Consist.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/Comp_FMap.shtml
+++ b/manual/3-6_DecoderPro3/Comp_FMap.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/Comp_GlobalCVs.shtml
+++ b/manual/3-6_DecoderPro3/Comp_GlobalCVs.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/Comp_LightFX.shtml
+++ b/manual/3-6_DecoderPro3/Comp_LightFX.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/Comp_ManfSpecific.shtml
+++ b/manual/3-6_DecoderPro3/Comp_ManfSpecific.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/Comp_Motor.shtml
+++ b/manual/3-6_DecoderPro3/Comp_Motor.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Comprehensive Programmer</h1>

--- a/manual/3-6_DecoderPro3/Comp_PrintData.shtml
+++ b/manual/3-6_DecoderPro3/Comp_PrintData.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Comprehensive Programmer</h1>

--- a/manual/3-6_DecoderPro3/Comp_PrintData_a.shtml
+++ b/manual/3-6_DecoderPro3/Comp_PrintData_a.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1><a name="Top"><img src="images/Comp_09a_PrintData.png" alt="Comprehensive Programmer - Advanced Features"  border=5 height=494 width=382 hspace="20"></a></h1>

--- a/manual/3-6_DecoderPro3/Comp_PrintData_b.shtml
+++ b/manual/3-6_DecoderPro3/Comp_PrintData_b.shtml
@@ -18,7 +18,7 @@ DecoderPro&reg; Comprehensive Programmer
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1><a name="Top"><img src="images/Comp_09b_PrintData.png" alt="Comprehensive Programmer - Advanced Features"  border=5 height=494 width=382 hspace="20"></a></h1>

--- a/manual/3-6_DecoderPro3/Comp_PrintData_c.shtml
+++ b/manual/3-6_DecoderPro3/Comp_PrintData_c.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
     <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/Comp_Setup_Roster.shtml
+++ b/manual/3-6_DecoderPro3/Comp_Setup_Roster.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top">

--- a/manual/3-6_DecoderPro3/Comp_SoundLevels.shtml
+++ b/manual/3-6_DecoderPro3/Comp_SoundLevels.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/Comp_Speed.shtml
+++ b/manual/3-6_DecoderPro3/Comp_Speed.shtml
@@ -15,7 +15,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/Comp_Speed_Talble.shtml
+++ b/manual/3-6_DecoderPro3/Comp_Speed_Talble.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/Error.shtml
+++ b/manual/3-6_DecoderPro3/Error.shtml
@@ -19,7 +19,7 @@ Error Messages
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Error Messages</h1>

--- a/manual/3-6_DecoderPro3/Installing_JMRI.shtml
+++ b/manual/3-6_DecoderPro3/Installing_JMRI.shtml
@@ -13,7 +13,7 @@
 </head>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/Main_CMRI.shtml
+++ b/manual/3-6_DecoderPro3/Main_CMRI.shtml
@@ -20,7 +20,7 @@ CMRI Menu
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-6_DecoderPro3/Main_EasyDCC.shtml
+++ b/manual/3-6_DecoderPro3/Main_EasyDCC.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/Main_FastClockSetup.shtml
+++ b/manual/3-6_DecoderPro3/Main_FastClockSetup.shtml
@@ -19,7 +19,7 @@ Tool Menu
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Tool Menu</h1>

--- a/manual/3-6_DecoderPro3/Main_GrapeVine.shtml
+++ b/manual/3-6_DecoderPro3/Main_GrapeVine.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-6_DecoderPro3/Main_LocoNet.shtml
+++ b/manual/3-6_DecoderPro3/Main_LocoNet.shtml
@@ -15,7 +15,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/Main_Monitor_Window.shtml
+++ b/manual/3-6_DecoderPro3/Main_Monitor_Window.shtml
@@ -13,7 +13,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 <h1>DecoderPro&reg; Main Window</h1>
 <h1>Communications Monitor Window</h1>

--- a/manual/3-6_DecoderPro3/Main_NCE.shtml
+++ b/manual/3-6_DecoderPro3/Main_NCE.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/Main_OakTreeSystems.shtml
+++ b/manual/3-6_DecoderPro3/Main_OakTreeSystems.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-6_DecoderPro3/Main_PRICOM.shtml
+++ b/manual/3-6_DecoderPro3/Main_PRICOM.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Debug Menu</h1>

--- a/manual/3-6_DecoderPro3/Main_Powerline.shtml
+++ b/manual/3-6_DecoderPro3/Main_Powerline.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-6_DecoderPro3/Main_QSI.shtml
+++ b/manual/3-6_DecoderPro3/Main_QSI.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-6_DecoderPro3/Main_RPS.shtml
+++ b/manual/3-6_DecoderPro3/Main_RPS.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-6_DecoderPro3/Main_SECSI.shtml
+++ b/manual/3-6_DecoderPro3/Main_SECSI.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-6_DecoderPro3/Main_SPROG.shtml
+++ b/manual/3-6_DecoderPro3/Main_SPROG.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-6_DecoderPro3/Main_Speedo.shtml
+++ b/manual/3-6_DecoderPro3/Main_Speedo.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-6_DecoderPro3/Main_TMCC.shtml
+++ b/manual/3-6_DecoderPro3/Main_TMCC.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-6_DecoderPro3/Main_XpressNet.shtml
+++ b/manual/3-6_DecoderPro3/Main_XpressNet.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-6_DecoderPro3/Main_Zimo.shtml
+++ b/manual/3-6_DecoderPro3/Main_Zimo.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-6_DecoderPro3/Main_acela.shtml
+++ b/manual/3-6_DecoderPro3/Main_acela.shtml
@@ -18,7 +18,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-6_DecoderPro3/Main_lightControl.shtml
+++ b/manual/3-6_DecoderPro3/Main_lightControl.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Tool Menu</h1>

--- a/manual/3-6_DecoderPro3/Main_wangrow.shtml
+++ b/manual/3-6_DecoderPro3/Main_wangrow.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/3-6_DecoderPro3/Programmer_OpsMode.shtml
+++ b/manual/3-6_DecoderPro3/Programmer_OpsMode.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <div align="center"><a name="Top"></a>

--- a/manual/3-6_DecoderPro3/Programmer_ServiceMode.shtml
+++ b/manual/3-6_DecoderPro3/Programmer_ServiceMode.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Programming Modes</h1>

--- a/manual/3-6_DecoderPro3/Programmer_Setup.shtml
+++ b/manual/3-6_DecoderPro3/Programmer_Setup.shtml
@@ -9,7 +9,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Using DecoderPro3&reg;</h1>

--- a/manual/3-6_DecoderPro3/Programmer_SingleCV.shtml
+++ b/manual/3-6_DecoderPro3/Programmer_SingleCV.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/RosterMedia.shtml
+++ b/manual/3-6_DecoderPro3/RosterMedia.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/Start_DCC.shtml
+++ b/manual/3-6_DecoderPro3/Start_DCC.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/Start_DCC_Hardware.shtml
+++ b/manual/3-6_DecoderPro3/Start_DCC_Hardware.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/Start_DCC_Systems.shtml
+++ b/manual/3-6_DecoderPro3/Start_DCC_Systems.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/Start_DecoderPro.shtml
+++ b/manual/3-6_DecoderPro3/Start_DecoderPro.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/Start_DecoderPro_New.shtml
+++ b/manual/3-6_DecoderPro3/Start_DecoderPro_New.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/Start_Preferences.shtml
+++ b/manual/3-6_DecoderPro3/Start_Preferences.shtml
@@ -23,7 +23,7 @@ function MM_jumpMenu(targ,selObj,restore){ //v3.0
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 <h1>Getting Started with DecoderPro3&reg;</h1>
 <h1>How do I set up my preferences?</h1>

--- a/manual/3-6_DecoderPro3/WiThrottle.shtml
+++ b/manual/3-6_DecoderPro3/WiThrottle.shtml
@@ -13,7 +13,7 @@
 <link rel="home" title="Home" href="/"><!-- /Style --></head><body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/dp3_Main_ConsistControl.shtml
+++ b/manual/3-6_DecoderPro3/dp3_Main_ConsistControl.shtml
@@ -13,7 +13,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Main Window</h1>

--- a/manual/3-6_DecoderPro3/dp3_Main_Main.shtml
+++ b/manual/3-6_DecoderPro3/dp3_Main_Main.shtml
@@ -14,7 +14,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/dp3_Main_Speedometer.shtml
+++ b/manual/3-6_DecoderPro3/dp3_Main_Speedometer.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Main Window</h1>

--- a/manual/3-6_DecoderPro3/dp3_Main_Throttle.shtml
+++ b/manual/3-6_DecoderPro3/dp3_Main_Throttle.shtml
@@ -13,7 +13,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/dp3_Main_Throttle_FrameProperties.shtml
+++ b/manual/3-6_DecoderPro3/dp3_Main_Throttle_FrameProperties.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/dp3_Main_Throttle_List.shtml
+++ b/manual/3-6_DecoderPro3/dp3_Main_Throttle_List.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/dp3_Main_Throttle_addressPanel.shtml
+++ b/manual/3-6_DecoderPro3/dp3_Main_Throttle_addressPanel.shtml
@@ -13,7 +13,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/dp3_Main_Throttle_controlPanel.shtml
+++ b/manual/3-6_DecoderPro3/dp3_Main_Throttle_controlPanel.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/dp3_Main_Throttle_functionPanel.shtml
+++ b/manual/3-6_DecoderPro3/dp3_Main_Throttle_functionPanel.shtml
@@ -14,7 +14,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/dp3_Main_Throttle_menubar.shtml
+++ b/manual/3-6_DecoderPro3/dp3_Main_Throttle_menubar.shtml
@@ -15,7 +15,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/dp3_Main_Throttle_toolbar.shtml
+++ b/manual/3-6_DecoderPro3/dp3_Main_Throttle_toolbar.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/dp3_Main_TurnoutControl.shtml
+++ b/manual/3-6_DecoderPro3/dp3_Main_TurnoutControl.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/dp3_Main_file_print_entry.shtml
+++ b/manual/3-6_DecoderPro3/dp3_Main_file_print_entry.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/dp3_decoderInfo.shtml
+++ b/manual/3-6_DecoderPro3/dp3_decoderInfo.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Main Window</h1>

--- a/manual/3-6_DecoderPro3/dp3_menubar.shtml
+++ b/manual/3-6_DecoderPro3/dp3_menubar.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/dp3_rosterTable.shtml
+++ b/manual/3-6_DecoderPro3/dp3_rosterTable.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Main Window</h1>

--- a/manual/3-6_DecoderPro3/dp3_settings_rosterGroups.shtml
+++ b/manual/3-6_DecoderPro3/dp3_settings_rosterGroups.shtml
@@ -15,7 +15,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/3-6_DecoderPro3/dp3_toobar.shtml
+++ b/manual/3-6_DecoderPro3/dp3_toobar.shtml
@@ -13,7 +13,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Main Window</h1>

--- a/manual/3-6_DecoderPro3/index.shtml
+++ b/manual/3-6_DecoderPro3/index.shtml
@@ -13,7 +13,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent"><a name="Top"></a>
 <h1>DecoderPro3&reg; Version 3.6</h1>
 <h3>Revised 2/17/2014</h3>

--- a/manual/DP3_2-14_manual/Adv_FunctionLabel.shtml
+++ b/manual/DP3_2-14_manual/Adv_FunctionLabel.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/DP3_2-14_manual/Basic_BasicPane.shtml
+++ b/manual/DP3_2-14_manual/Basic_BasicPane.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/DP3_2-14_manual/Basic_Mode.shtml
+++ b/manual/DP3_2-14_manual/Basic_Mode.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Programming Modes
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/DP3_2-14_manual/Basic_Start.shtml
+++ b/manual/DP3_2-14_manual/Basic_Start.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>The Basic Programmer</h1>

--- a/manual/DP3_2-14_manual/Comp_Advanced.shtml
+++ b/manual/DP3_2-14_manual/Comp_Advanced.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/DP3_2-14_manual/Comp_Analog.shtml
+++ b/manual/DP3_2-14_manual/Comp_Analog.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/DP3_2-14_manual/Comp_Basic.shtml
+++ b/manual/DP3_2-14_manual/Comp_Basic.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/DP3_2-14_manual/Comp_Consist.shtml
+++ b/manual/DP3_2-14_manual/Comp_Consist.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/DP3_2-14_manual/Comp_FMap.shtml
+++ b/manual/DP3_2-14_manual/Comp_FMap.shtml
@@ -18,7 +18,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/DP3_2-14_manual/Comp_GlobalCVs.shtml
+++ b/manual/DP3_2-14_manual/Comp_GlobalCVs.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/DP3_2-14_manual/Comp_LightFX.shtml
+++ b/manual/DP3_2-14_manual/Comp_LightFX.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/DP3_2-14_manual/Comp_ManfSpecific.shtml
+++ b/manual/DP3_2-14_manual/Comp_ManfSpecific.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/DP3_2-14_manual/Comp_Motor.shtml
+++ b/manual/DP3_2-14_manual/Comp_Motor.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Comprehensive Programmer</h1>

--- a/manual/DP3_2-14_manual/Comp_PrintData.shtml
+++ b/manual/DP3_2-14_manual/Comp_PrintData.shtml
@@ -20,7 +20,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Comprehensive Programmer</h1>

--- a/manual/DP3_2-14_manual/Comp_PrintData_a.shtml
+++ b/manual/DP3_2-14_manual/Comp_PrintData_a.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1><a name="Top"><img src="images/Comp_09a_PrintData.png" alt="Comprehensive Programmer - Advanced Features"  border=5 height=494 width=382 hspace="20"></a></h1>

--- a/manual/DP3_2-14_manual/Comp_PrintData_b.shtml
+++ b/manual/DP3_2-14_manual/Comp_PrintData_b.shtml
@@ -18,7 +18,7 @@ DecoderPro&reg; Comprehensive Programmer
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1><a name="Top"><img src="images/Comp_09b_PrintData.png" alt="Comprehensive Programmer - Advanced Features"  border=5 height=494 width=382 hspace="20"></a></h1>

--- a/manual/DP3_2-14_manual/Comp_PrintData_c.shtml
+++ b/manual/DP3_2-14_manual/Comp_PrintData_c.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
     <a name="Top"></a>

--- a/manual/DP3_2-14_manual/Comp_Setup_Roster.shtml
+++ b/manual/DP3_2-14_manual/Comp_Setup_Roster.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
     <a name="Top"></a>

--- a/manual/DP3_2-14_manual/Comp_SoundFX.shtml
+++ b/manual/DP3_2-14_manual/Comp_SoundFX.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/DP3_2-14_manual/Comp_SoundLevels.shtml
+++ b/manual/DP3_2-14_manual/Comp_SoundLevels.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/DP3_2-14_manual/Comp_Speed.shtml
+++ b/manual/DP3_2-14_manual/Comp_Speed.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/DP3_2-14_manual/Comp_Speed_Talble.shtml
+++ b/manual/DP3_2-14_manual/Comp_Speed_Talble.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/DP3_2-14_manual/Error.shtml
+++ b/manual/DP3_2-14_manual/Error.shtml
@@ -19,7 +19,7 @@ Error Messages
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Error Messages</h1>

--- a/manual/DP3_2-14_manual/Installing_JMRI.shtml
+++ b/manual/DP3_2-14_manual/Installing_JMRI.shtml
@@ -15,7 +15,7 @@
 </head>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/DP3_2-14_manual/Main_CMRI.shtml
+++ b/manual/DP3_2-14_manual/Main_CMRI.shtml
@@ -20,7 +20,7 @@ CMRI Menu
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/DP3_2-14_manual/Main_EasyDCC.shtml
+++ b/manual/DP3_2-14_manual/Main_EasyDCC.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/DP3_2-14_manual/Main_FastClockSetup.shtml
+++ b/manual/DP3_2-14_manual/Main_FastClockSetup.shtml
@@ -19,7 +19,7 @@ Tool Menu
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Tool Menu</h1>

--- a/manual/DP3_2-14_manual/Main_GrapeVine.shtml
+++ b/manual/DP3_2-14_manual/Main_GrapeVine.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/DP3_2-14_manual/Main_LocoNet.shtml
+++ b/manual/DP3_2-14_manual/Main_LocoNet.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/DP3_2-14_manual/Main_Monitor_Window.shtml
+++ b/manual/DP3_2-14_manual/Main_Monitor_Window.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/DP3_2-14_manual/Main_NCE.shtml
+++ b/manual/DP3_2-14_manual/Main_NCE.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/DP3_2-14_manual/Main_OakTreeSystems.shtml
+++ b/manual/DP3_2-14_manual/Main_OakTreeSystems.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/DP3_2-14_manual/Main_PRICOM.shtml
+++ b/manual/DP3_2-14_manual/Main_PRICOM.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Debug Menu</h1>

--- a/manual/DP3_2-14_manual/Main_Powerline.shtml
+++ b/manual/DP3_2-14_manual/Main_Powerline.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/DP3_2-14_manual/Main_QSI.shtml
+++ b/manual/DP3_2-14_manual/Main_QSI.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/DP3_2-14_manual/Main_RPS.shtml
+++ b/manual/DP3_2-14_manual/Main_RPS.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/DP3_2-14_manual/Main_SECSI.shtml
+++ b/manual/DP3_2-14_manual/Main_SECSI.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/DP3_2-14_manual/Main_SPROG.shtml
+++ b/manual/DP3_2-14_manual/Main_SPROG.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/DP3_2-14_manual/Main_TMCC.shtml
+++ b/manual/DP3_2-14_manual/Main_TMCC.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/DP3_2-14_manual/Main_XpressNet.shtml
+++ b/manual/DP3_2-14_manual/Main_XpressNet.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/DP3_2-14_manual/Main_Zimo.shtml
+++ b/manual/DP3_2-14_manual/Main_Zimo.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/DP3_2-14_manual/Main_acela.shtml
+++ b/manual/DP3_2-14_manual/Main_acela.shtml
@@ -18,7 +18,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/DP3_2-14_manual/Main_lightControl.shtml
+++ b/manual/DP3_2-14_manual/Main_lightControl.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Tool Menu</h1>

--- a/manual/DP3_2-14_manual/Main_wangrow.shtml
+++ b/manual/DP3_2-14_manual/Main_wangrow.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/DP3_2-14_manual/Programmer_Multi_Decoder.shtml
+++ b/manual/DP3_2-14_manual/Programmer_Multi_Decoder.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Main Window</h1>

--- a/manual/DP3_2-14_manual/Programmer_OpsMode.shtml
+++ b/manual/DP3_2-14_manual/Programmer_OpsMode.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <div align="center"><a name="Top"></a>

--- a/manual/DP3_2-14_manual/Programmer_ServiceMode.shtml
+++ b/manual/DP3_2-14_manual/Programmer_ServiceMode.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Programming Modes</h1>

--- a/manual/DP3_2-14_manual/Programmer_Setup.shtml
+++ b/manual/DP3_2-14_manual/Programmer_Setup.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Using DecoderPro3&reg;</h1>

--- a/manual/DP3_2-14_manual/Programmer_SingleCV.shtml
+++ b/manual/DP3_2-14_manual/Programmer_SingleCV.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/DP3_2-14_manual/RosterMedia.shtml
+++ b/manual/DP3_2-14_manual/RosterMedia.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/DP3_2-14_manual/Start_DCC.shtml
+++ b/manual/DP3_2-14_manual/Start_DCC.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/DP3_2-14_manual/Start_DCC_Hardware.shtml
+++ b/manual/DP3_2-14_manual/Start_DCC_Hardware.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/DP3_2-14_manual/Start_DCC_Systems.shtml
+++ b/manual/DP3_2-14_manual/Start_DCC_Systems.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/DP3_2-14_manual/Start_DecoderPro.shtml
+++ b/manual/DP3_2-14_manual/Start_DecoderPro.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/DP3_2-14_manual/Start_DecoderPro_New.shtml
+++ b/manual/DP3_2-14_manual/Start_DecoderPro_New.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/DP3_2-14_manual/Start_Preferences.shtml
+++ b/manual/DP3_2-14_manual/Start_Preferences.shtml
@@ -25,7 +25,7 @@ function MM_jumpMenu(targ,selObj,restore){ //v3.0
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 <h1>Getting Started with DecoderPro3&reg;</h1>
 <h1>How do I set up my preferences?</h1>

--- a/manual/DP3_2-14_manual/Throttle.shtml
+++ b/manual/DP3_2-14_manual/Throttle.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/DP3_2-14_manual/dp3_Main_ConsistControl.shtml
+++ b/manual/DP3_2-14_manual/dp3_Main_ConsistControl.shtml
@@ -19,7 +19,7 @@ Tool Menu
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Main Window</h1>

--- a/manual/DP3_2-14_manual/dp3_Main_Main.shtml
+++ b/manual/DP3_2-14_manual/dp3_Main_Main.shtml
@@ -15,7 +15,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/DP3_2-14_manual/dp3_Main_Speedometer.shtml
+++ b/manual/DP3_2-14_manual/dp3_Main_Speedometer.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Main Window</h1>

--- a/manual/DP3_2-14_manual/dp3_Main_Throttle.shtml
+++ b/manual/DP3_2-14_manual/dp3_Main_Throttle.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/DP3_2-14_manual/dp3_Main_Throttle_FrameProperties.shtml
+++ b/manual/DP3_2-14_manual/dp3_Main_Throttle_FrameProperties.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/DP3_2-14_manual/dp3_Main_Throttle_List.shtml
+++ b/manual/DP3_2-14_manual/dp3_Main_Throttle_List.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/DP3_2-14_manual/dp3_Main_Throttle_addressPanel.shtml
+++ b/manual/DP3_2-14_manual/dp3_Main_Throttle_addressPanel.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/DP3_2-14_manual/dp3_Main_Throttle_controlPanel.shtml
+++ b/manual/DP3_2-14_manual/dp3_Main_Throttle_controlPanel.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/DP3_2-14_manual/dp3_Main_Throttle_functionPanel.shtml
+++ b/manual/DP3_2-14_manual/dp3_Main_Throttle_functionPanel.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/DP3_2-14_manual/dp3_Main_Throttle_menubar.shtml
+++ b/manual/DP3_2-14_manual/dp3_Main_Throttle_menubar.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/DP3_2-14_manual/dp3_Main_Throttle_toolbar.shtml
+++ b/manual/DP3_2-14_manual/dp3_Main_Throttle_toolbar.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/DP3_2-14_manual/dp3_Main_TurnoutControl.shtml
+++ b/manual/DP3_2-14_manual/dp3_Main_TurnoutControl.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/DP3_2-14_manual/dp3_Main_file_print_entry.shtml
+++ b/manual/DP3_2-14_manual/dp3_Main_file_print_entry.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/DP3_2-14_manual/dp3_decoderInfo.shtml
+++ b/manual/DP3_2-14_manual/dp3_decoderInfo.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Main Window</h1>

--- a/manual/DP3_2-14_manual/dp3_menubar.shtml
+++ b/manual/DP3_2-14_manual/dp3_menubar.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/DP3_2-14_manual/dp3_rosterTable.shtml
+++ b/manual/DP3_2-14_manual/dp3_rosterTable.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Main Window</h1>

--- a/manual/DP3_2-14_manual/dp3_toobar.shtml
+++ b/manual/DP3_2-14_manual/dp3_toobar.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro3&reg; Main Window</h1>

--- a/manual/DP3_2-14_manual/index.shtml
+++ b/manual/DP3_2-14_manual/index.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Adv_FunctionLabel.shtml
+++ b/manual/JMRI_2-12_Manual/Adv_FunctionLabel.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Adv_RosterMedia.shtml
+++ b/manual/JMRI_2-12_Manual/Adv_RosterMedia.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Adv_start.shtml
+++ b/manual/JMRI_2-12_Manual/Adv_start.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
   <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Basic_BasicPane.shtml
+++ b/manual/JMRI_2-12_Manual/Basic_BasicPane.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Basic_Mode.shtml
+++ b/manual/JMRI_2-12_Manual/Basic_Mode.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Programming Modes
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Basic_Programming.shtml
+++ b/manual/JMRI_2-12_Manual/Basic_Programming.shtml
@@ -19,7 +19,7 @@ Using DecoderPro&reg;
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Using DecoderPro&reg;</h1>

--- a/manual/JMRI_2-12_Manual/Basic_Start.shtml
+++ b/manual/JMRI_2-12_Manual/Basic_Start.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>The Basic Programmer</h1>

--- a/manual/JMRI_2-12_Manual/Comp_Advanced.shtml
+++ b/manual/JMRI_2-12_Manual/Comp_Advanced.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Comp_Analog.shtml
+++ b/manual/JMRI_2-12_Manual/Comp_Analog.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Comp_Basic.shtml
+++ b/manual/JMRI_2-12_Manual/Comp_Basic.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Comp_Consist.shtml
+++ b/manual/JMRI_2-12_Manual/Comp_Consist.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Comp_FMap.shtml
+++ b/manual/JMRI_2-12_Manual/Comp_FMap.shtml
@@ -18,7 +18,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Comp_FunctionLabel.shtml
+++ b/manual/JMRI_2-12_Manual/Comp_FunctionLabel.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Comp_GlobalCVs.shtml
+++ b/manual/JMRI_2-12_Manual/Comp_GlobalCVs.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Comp_LightFX.shtml
+++ b/manual/JMRI_2-12_Manual/Comp_LightFX.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Comp_ManfSpecific.shtml
+++ b/manual/JMRI_2-12_Manual/Comp_ManfSpecific.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Comp_Motor.shtml
+++ b/manual/JMRI_2-12_Manual/Comp_Motor.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Comprehensive Programmer</h1>

--- a/manual/JMRI_2-12_Manual/Comp_PrintData.shtml
+++ b/manual/JMRI_2-12_Manual/Comp_PrintData.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Comprehensive Programmer</h1>

--- a/manual/JMRI_2-12_Manual/Comp_PrintData_a.shtml
+++ b/manual/JMRI_2-12_Manual/Comp_PrintData_a.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1><a name="Top"><img src="images/Comp_09a_PrintData.png" alt="Comprehensive Programmer - Advanced Features"  border=5 height=494 width=382 hspace="20"></a></h1>

--- a/manual/JMRI_2-12_Manual/Comp_PrintData_b.shtml
+++ b/manual/JMRI_2-12_Manual/Comp_PrintData_b.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1><a name="Top"><img src="images/Comp_09b_PrintData.png" alt="Comprehensive Programmer - Advanced Features"  border=5 height=494 width=382 hspace="20"></a></h1>

--- a/manual/JMRI_2-12_Manual/Comp_PrintData_c.shtml
+++ b/manual/JMRI_2-12_Manual/Comp_PrintData_c.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
     <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Comp_Setup_Roster.shtml
+++ b/manual/JMRI_2-12_Manual/Comp_Setup_Roster.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
   <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Comp_SoundFX.shtml
+++ b/manual/JMRI_2-12_Manual/Comp_SoundFX.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Comp_SoundLevels.shtml
+++ b/manual/JMRI_2-12_Manual/Comp_SoundLevels.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Comp_Speed.shtml
+++ b/manual/JMRI_2-12_Manual/Comp_Speed.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Comp_Speed_Talble.shtml
+++ b/manual/JMRI_2-12_Manual/Comp_Speed_Talble.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Dcode_Format.shtml
+++ b/manual/JMRI_2-12_Manual/Dcode_Format.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Dcode_Start.shtml
+++ b/manual/JMRI_2-12_Manual/Dcode_Start.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Dcode_Submit.shtml
+++ b/manual/JMRI_2-12_Manual/Dcode_Submit.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Dcode_Testing.shtml
+++ b/manual/JMRI_2-12_Manual/Dcode_Testing.shtml
@@ -19,7 +19,7 @@ Decoder Definition
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Decoder Definition</h1>

--- a/manual/JMRI_2-12_Manual/Error.shtml
+++ b/manual/JMRI_2-12_Manual/Error.shtml
@@ -19,7 +19,7 @@ Error Messages
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Error Messages</h1>

--- a/manual/JMRI_2-12_Manual/Installing_JMRI.shtml
+++ b/manual/JMRI_2-12_Manual/Installing_JMRI.shtml
@@ -15,7 +15,7 @@
 </head>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Main_CMRI.shtml
+++ b/manual/JMRI_2-12_Manual/Main_CMRI.shtml
@@ -20,7 +20,7 @@ CMRI Menu
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/JMRI_2-12_Manual/Main_ConsistControl.shtml
+++ b/manual/JMRI_2-12_Manual/Main_ConsistControl.shtml
@@ -19,7 +19,7 @@ Tool Menu
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Tool Menu </h1>

--- a/manual/JMRI_2-12_Manual/Main_Debug.shtml
+++ b/manual/JMRI_2-12_Manual/Main_Debug.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Main_EasyDCC.shtml
+++ b/manual/JMRI_2-12_Manual/Main_EasyDCC.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Main_Edit.shtml
+++ b/manual/JMRI_2-12_Manual/Main_Edit.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Main_FastClockSetup.shtml
+++ b/manual/JMRI_2-12_Manual/Main_FastClockSetup.shtml
@@ -19,7 +19,7 @@ Tool Menu
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Tool Menu</h1>

--- a/manual/JMRI_2-12_Manual/Main_File.shtml
+++ b/manual/JMRI_2-12_Manual/Main_File.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Main_GrapeVine.shtml
+++ b/manual/JMRI_2-12_Manual/Main_GrapeVine.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/JMRI_2-12_Manual/Main_Help.shtml
+++ b/manual/JMRI_2-12_Manual/Main_Help.shtml
@@ -18,7 +18,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Main_LocoNet.shtml
+++ b/manual/JMRI_2-12_Manual/Main_LocoNet.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Main_Main.shtml
+++ b/manual/JMRI_2-12_Manual/Main_Main.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Main_Menu.shtml
+++ b/manual/JMRI_2-12_Manual/Main_Menu.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Main_Monitor_Window.shtml
+++ b/manual/JMRI_2-12_Manual/Main_Monitor_Window.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/JMRI_2-12_Manual/Main_NCE.shtml
+++ b/manual/JMRI_2-12_Manual/Main_NCE.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Main_OakTreeSystems.shtml
+++ b/manual/JMRI_2-12_Manual/Main_OakTreeSystems.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/JMRI_2-12_Manual/Main_Operations.shtml
+++ b/manual/JMRI_2-12_Manual/Main_Operations.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Main_PRICOM.shtml
+++ b/manual/JMRI_2-12_Manual/Main_PRICOM.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Debug Menu</h1>

--- a/manual/JMRI_2-12_Manual/Main_Panels.shtml
+++ b/manual/JMRI_2-12_Manual/Main_Panels.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Main_Powerline.shtml
+++ b/manual/JMRI_2-12_Manual/Main_Powerline.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/JMRI_2-12_Manual/Main_QSI.shtml
+++ b/manual/JMRI_2-12_Manual/Main_QSI.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/JMRI_2-12_Manual/Main_RPS.shtml
+++ b/manual/JMRI_2-12_Manual/Main_RPS.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/JMRI_2-12_Manual/Main_Roster.shtml
+++ b/manual/JMRI_2-12_Manual/Main_Roster.shtml
@@ -15,7 +15,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Main_RosterGroup.shtml
+++ b/manual/JMRI_2-12_Manual/Main_RosterGroup.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Main_SECSI.shtml
+++ b/manual/JMRI_2-12_Manual/Main_SECSI.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/JMRI_2-12_Manual/Main_SPROG.shtml
+++ b/manual/JMRI_2-12_Manual/Main_SPROG.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/JMRI_2-12_Manual/Main_Speedometer.shtml
+++ b/manual/JMRI_2-12_Manual/Main_Speedometer.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Tool Menu</h1>

--- a/manual/JMRI_2-12_Manual/Main_Speeometer.shtml
+++ b/manual/JMRI_2-12_Manual/Main_Speeometer.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Main_TMCC.shtml
+++ b/manual/JMRI_2-12_Manual/Main_TMCC.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/JMRI_2-12_Manual/Main_Throttle.shtml
+++ b/manual/JMRI_2-12_Manual/Main_Throttle.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Main_Tool.shtml
+++ b/manual/JMRI_2-12_Manual/Main_Tool.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Main_TurnoutControl.shtml
+++ b/manual/JMRI_2-12_Manual/Main_TurnoutControl.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Main_VSD.shtml
+++ b/manual/JMRI_2-12_Manual/Main_VSD.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Debug Menu</h1>

--- a/manual/JMRI_2-12_Manual/Main_Window.shtml
+++ b/manual/JMRI_2-12_Manual/Main_Window.shtml
@@ -18,7 +18,7 @@ DecoderPro&reg; Main Window
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/JMRI_2-12_Manual/Main_XpressNet.shtml
+++ b/manual/JMRI_2-12_Manual/Main_XpressNet.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/JMRI_2-12_Manual/Main_Zimo.shtml
+++ b/manual/JMRI_2-12_Manual/Main_Zimo.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/JMRI_2-12_Manual/Main_acela.shtml
+++ b/manual/JMRI_2-12_Manual/Main_acela.shtml
@@ -18,7 +18,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/JMRI_2-12_Manual/Main_lightControl.shtml
+++ b/manual/JMRI_2-12_Manual/Main_lightControl.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Tool Menu</h1>

--- a/manual/JMRI_2-12_Manual/Main_wangrow.shtml
+++ b/manual/JMRI_2-12_Manual/Main_wangrow.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/JMRI_2-12_Manual/Multi_Decoder_Control.shtml
+++ b/manual/JMRI_2-12_Manual/Multi_Decoder_Control.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Main Window<
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/JMRI_2-12_Manual/Ops_AddCars.shtml
+++ b/manual/JMRI_2-12_Manual/Ops_AddCars.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Ops_AddEngine.shtml
+++ b/manual/JMRI_2-12_Manual/Ops_AddEngine.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Ops_AddInterchange.shtml
+++ b/manual/JMRI_2-12_Manual/Ops_AddInterchange.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Ops_AddRoutes.shtml
+++ b/manual/JMRI_2-12_Manual/Ops_AddRoutes.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Ops_AddSiding.shtml
+++ b/manual/JMRI_2-12_Manual/Ops_AddSiding.shtml
@@ -18,7 +18,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Ops_AddStaging.shtml
+++ b/manual/JMRI_2-12_Manual/Ops_AddStaging.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Ops_AddTrain.shtml
+++ b/manual/JMRI_2-12_Manual/Ops_AddTrain.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Ops_AddYard.shtml
+++ b/manual/JMRI_2-12_Manual/Ops_AddYard.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Ops_CarAttributes.shtml
+++ b/manual/JMRI_2-12_Manual/Ops_CarAttributes.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Ops_Cars.shtml
+++ b/manual/JMRI_2-12_Manual/Ops_Cars.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Ops_EngineAttributes.shtml
+++ b/manual/JMRI_2-12_Manual/Ops_EngineAttributes.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Ops_Engines.shtml
+++ b/manual/JMRI_2-12_Manual/Ops_Engines.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Ops_ImportCarsFile.shtml
+++ b/manual/JMRI_2-12_Manual/Ops_ImportCarsFile.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Ops_ImportEngines.shtml
+++ b/manual/JMRI_2-12_Manual/Ops_ImportEngines.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Ops_Locations.shtml
+++ b/manual/JMRI_2-12_Manual/Ops_Locations.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Ops_Locations_Modify_Trains.shtml
+++ b/manual/JMRI_2-12_Manual/Ops_Locations_Modify_Trains.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Ops_Locations_byCar.shtml
+++ b/manual/JMRI_2-12_Manual/Ops_Locations_byCar.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Ops_Locations_setCars.shtml
+++ b/manual/JMRI_2-12_Manual/Ops_Locations_setCars.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Ops_PrintOptions.shtml
+++ b/manual/JMRI_2-12_Manual/Ops_PrintOptions.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Ops_Routes.shtml
+++ b/manual/JMRI_2-12_Manual/Ops_Routes.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Ops_Settings.shtml
+++ b/manual/JMRI_2-12_Manual/Ops_Settings.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Ops_Start.shtml
+++ b/manual/JMRI_2-12_Manual/Ops_Start.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Ops_Trains.shtml
+++ b/manual/JMRI_2-12_Manual/Ops_Trains.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Using JMRI&reg; to Operate Trains</h1>

--- a/manual/JMRI_2-12_Manual/Ops_TrainsModify.shtml
+++ b/manual/JMRI_2-12_Manual/Ops_TrainsModify.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Using JMRI&reg; to Operate Trains</h1>

--- a/manual/JMRI_2-12_Manual/Ops_Trains_BuildOptions.shtml
+++ b/manual/JMRI_2-12_Manual/Ops_Trains_BuildOptions.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Ops_Trains_Timetable.shtml
+++ b/manual/JMRI_2-12_Manual/Ops_Trains_Timetable.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Using JMRI&reg; to Operate Trains</h1>

--- a/manual/JMRI_2-12_Manual/Ops_TripThruOperations.shtml
+++ b/manual/JMRI_2-12_Manual/Ops_TripThruOperations.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Ops_schedule.shtml
+++ b/manual/JMRI_2-12_Manual/Ops_schedule.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Using JMRI&reg; to Operate Trains</h1>

--- a/manual/JMRI_2-12_Manual/Programmer_Multi_Decoder.shtml
+++ b/manual/JMRI_2-12_Manual/Programmer_Multi_Decoder.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/JMRI_2-12_Manual/Programmer_OpsMode.shtml
+++ b/manual/JMRI_2-12_Manual/Programmer_OpsMode.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <div align="center"><a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Programmer_ServiceMode.shtml
+++ b/manual/JMRI_2-12_Manual/Programmer_ServiceMode.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Programming Modes</h1>

--- a/manual/JMRI_2-12_Manual/Programmer_Setup.shtml
+++ b/manual/JMRI_2-12_Manual/Programmer_Setup.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Using DecoderPro&reg;</h1>

--- a/manual/JMRI_2-12_Manual/Programmer_SingleCV.shtml
+++ b/manual/JMRI_2-12_Manual/Programmer_SingleCV.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Programmer_Start.shtml
+++ b/manual/JMRI_2-12_Manual/Programmer_Start.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <div align="center"><a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Simple_Programmer.shtml
+++ b/manual/JMRI_2-12_Manual/Simple_Programmer.shtml
@@ -19,7 +19,7 @@ JMRI: Simple Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/JMRI_2-12_Manual/Start_DCC.shtml
+++ b/manual/JMRI_2-12_Manual/Start_DCC.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Start_DCC_Hardware.shtml
+++ b/manual/JMRI_2-12_Manual/Start_DCC_Hardware.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Start_DCC_Systems.shtml
+++ b/manual/JMRI_2-12_Manual/Start_DCC_Systems.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Start_DecoderPro.shtml
+++ b/manual/JMRI_2-12_Manual/Start_DecoderPro.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-12_Manual/Start_Preferences.shtml
+++ b/manual/JMRI_2-12_Manual/Start_Preferences.shtml
@@ -25,7 +25,7 @@ function MM_jumpMenu(targ,selObj,restore){ //v3.0
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 <h1>Getting Started with DecoderPro&reg;</h1>
 <h1>How do I set up my preferences?</h1>

--- a/manual/JMRI_2-12_Manual/index.shtml
+++ b/manual/JMRI_2-12_Manual/index.shtml
@@ -15,7 +15,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Adv_FunctionLabel.shtml
+++ b/manual/JMRI_2-14_manual/Adv_FunctionLabel.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Adv_RosterMedia.shtml
+++ b/manual/JMRI_2-14_manual/Adv_RosterMedia.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Adv_start.shtml
+++ b/manual/JMRI_2-14_manual/Adv_start.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
     <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Basic_BasicPane.shtml
+++ b/manual/JMRI_2-14_manual/Basic_BasicPane.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Basic_Mode.shtml
+++ b/manual/JMRI_2-14_manual/Basic_Mode.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Programming Modes
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Basic_Programming.shtml
+++ b/manual/JMRI_2-14_manual/Basic_Programming.shtml
@@ -19,7 +19,7 @@ Using DecoderPro&reg;
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Using DecoderPro&reg;</h1>

--- a/manual/JMRI_2-14_manual/Basic_Start.shtml
+++ b/manual/JMRI_2-14_manual/Basic_Start.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>The Basic Programmer</h1>

--- a/manual/JMRI_2-14_manual/Comp_Advanced.shtml
+++ b/manual/JMRI_2-14_manual/Comp_Advanced.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Comp_Analog.shtml
+++ b/manual/JMRI_2-14_manual/Comp_Analog.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Comp_Basic.shtml
+++ b/manual/JMRI_2-14_manual/Comp_Basic.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Comp_Consist.shtml
+++ b/manual/JMRI_2-14_manual/Comp_Consist.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Comp_FMap.shtml
+++ b/manual/JMRI_2-14_manual/Comp_FMap.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Comp_FunctionLabel.shtml
+++ b/manual/JMRI_2-14_manual/Comp_FunctionLabel.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Comp_GlobalCVs.shtml
+++ b/manual/JMRI_2-14_manual/Comp_GlobalCVs.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Comp_LightFX.shtml
+++ b/manual/JMRI_2-14_manual/Comp_LightFX.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Comp_ManfSpecific.shtml
+++ b/manual/JMRI_2-14_manual/Comp_ManfSpecific.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Comp_Motor.shtml
+++ b/manual/JMRI_2-14_manual/Comp_Motor.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Comprehensive Programmer</h1>

--- a/manual/JMRI_2-14_manual/Comp_PrintData.shtml
+++ b/manual/JMRI_2-14_manual/Comp_PrintData.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 <h1>DecoderPro&reg; Comprehensive Programmer</h1>
 <h2>Printing Decoder Data</h2>

--- a/manual/JMRI_2-14_manual/Comp_PrintData_a.shtml
+++ b/manual/JMRI_2-14_manual/Comp_PrintData_a.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1><a name="Top">Print Preview 1</a></h1>

--- a/manual/JMRI_2-14_manual/Comp_PrintData_b.shtml
+++ b/manual/JMRI_2-14_manual/Comp_PrintData_b.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1><a name="Top">Print Preview 2</a></h1>

--- a/manual/JMRI_2-14_manual/Comp_PrintData_c.shtml
+++ b/manual/JMRI_2-14_manual/Comp_PrintData_c.shtml
@@ -19,7 +19,7 @@ DecoderPro&reg; Comprehensive Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"><h1>Print Preview 3</h1></a>

--- a/manual/JMRI_2-14_manual/Comp_Setup_Roster.shtml
+++ b/manual/JMRI_2-14_manual/Comp_Setup_Roster.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top">

--- a/manual/JMRI_2-14_manual/Comp_SoundFX.shtml
+++ b/manual/JMRI_2-14_manual/Comp_SoundFX.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Comp_SoundLevels.shtml
+++ b/manual/JMRI_2-14_manual/Comp_SoundLevels.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Comp_Speed.shtml
+++ b/manual/JMRI_2-14_manual/Comp_Speed.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Comp_Speed_Talble.shtml
+++ b/manual/JMRI_2-14_manual/Comp_Speed_Talble.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Dcode_Format.shtml
+++ b/manual/JMRI_2-14_manual/Dcode_Format.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Dcode_Start.shtml
+++ b/manual/JMRI_2-14_manual/Dcode_Start.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Dcode_Submit.shtml
+++ b/manual/JMRI_2-14_manual/Dcode_Submit.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Dcode_Testing.shtml
+++ b/manual/JMRI_2-14_manual/Dcode_Testing.shtml
@@ -18,7 +18,7 @@ Decoder Definition
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Decoder Definition</h1>

--- a/manual/JMRI_2-14_manual/Error.shtml
+++ b/manual/JMRI_2-14_manual/Error.shtml
@@ -19,7 +19,7 @@ Error Messages
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Error Messages</h1>

--- a/manual/JMRI_2-14_manual/Installing_JMRI.shtml
+++ b/manual/JMRI_2-14_manual/Installing_JMRI.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Main_CMRI.shtml
+++ b/manual/JMRI_2-14_manual/Main_CMRI.shtml
@@ -18,7 +18,7 @@ CMRI Menu
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/JMRI_2-14_manual/Main_ConsistControl.shtml
+++ b/manual/JMRI_2-14_manual/Main_ConsistControl.shtml
@@ -18,7 +18,7 @@ Tool Menu
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Tool Menu </h1>

--- a/manual/JMRI_2-14_manual/Main_Debug.shtml
+++ b/manual/JMRI_2-14_manual/Main_Debug.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Main_EasyDCC.shtml
+++ b/manual/JMRI_2-14_manual/Main_EasyDCC.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Main_Edit.shtml
+++ b/manual/JMRI_2-14_manual/Main_Edit.shtml
@@ -15,7 +15,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Main_FastClockSetup.shtml
+++ b/manual/JMRI_2-14_manual/Main_FastClockSetup.shtml
@@ -18,7 +18,7 @@ Tool Menu
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Tool Menu</h1>

--- a/manual/JMRI_2-14_manual/Main_File.shtml
+++ b/manual/JMRI_2-14_manual/Main_File.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Main_GrapeVine.shtml
+++ b/manual/JMRI_2-14_manual/Main_GrapeVine.shtml
@@ -18,7 +18,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/JMRI_2-14_manual/Main_Help.shtml
+++ b/manual/JMRI_2-14_manual/Main_Help.shtml
@@ -16,7 +16,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Main_LocoNet.shtml
+++ b/manual/JMRI_2-14_manual/Main_LocoNet.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Main_Main.shtml
+++ b/manual/JMRI_2-14_manual/Main_Main.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Main_Menu.shtml
+++ b/manual/JMRI_2-14_manual/Main_Menu.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Main_Monitor_Window.shtml
+++ b/manual/JMRI_2-14_manual/Main_Monitor_Window.shtml
@@ -18,7 +18,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/JMRI_2-14_manual/Main_NCE.shtml
+++ b/manual/JMRI_2-14_manual/Main_NCE.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Main_OakTreeSystems.shtml
+++ b/manual/JMRI_2-14_manual/Main_OakTreeSystems.shtml
@@ -18,7 +18,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/JMRI_2-14_manual/Main_Operations.shtml
+++ b/manual/JMRI_2-14_manual/Main_Operations.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Main_PRICOM.shtml
+++ b/manual/JMRI_2-14_manual/Main_PRICOM.shtml
@@ -18,7 +18,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Debug Menu</h1>

--- a/manual/JMRI_2-14_manual/Main_Panels.shtml
+++ b/manual/JMRI_2-14_manual/Main_Panels.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Main_Powerline.shtml
+++ b/manual/JMRI_2-14_manual/Main_Powerline.shtml
@@ -18,7 +18,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/JMRI_2-14_manual/Main_QSI.shtml
+++ b/manual/JMRI_2-14_manual/Main_QSI.shtml
@@ -18,7 +18,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/JMRI_2-14_manual/Main_RPS.shtml
+++ b/manual/JMRI_2-14_manual/Main_RPS.shtml
@@ -18,7 +18,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/JMRI_2-14_manual/Main_Roster.shtml
+++ b/manual/JMRI_2-14_manual/Main_Roster.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Main_RosterGroup.shtml
+++ b/manual/JMRI_2-14_manual/Main_RosterGroup.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Main_SECSI.shtml
+++ b/manual/JMRI_2-14_manual/Main_SECSI.shtml
@@ -18,7 +18,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/JMRI_2-14_manual/Main_SPROG.shtml
+++ b/manual/JMRI_2-14_manual/Main_SPROG.shtml
@@ -18,7 +18,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/JMRI_2-14_manual/Main_Speedometer.shtml
+++ b/manual/JMRI_2-14_manual/Main_Speedometer.shtml
@@ -18,7 +18,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Tool Menu</h1>

--- a/manual/JMRI_2-14_manual/Main_Speeometer.shtml
+++ b/manual/JMRI_2-14_manual/Main_Speeometer.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Main_TMCC.shtml
+++ b/manual/JMRI_2-14_manual/Main_TMCC.shtml
@@ -18,7 +18,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/JMRI_2-14_manual/Main_Throttle.shtml
+++ b/manual/JMRI_2-14_manual/Main_Throttle.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Main_Tool.shtml
+++ b/manual/JMRI_2-14_manual/Main_Tool.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Main_TurnoutControl.shtml
+++ b/manual/JMRI_2-14_manual/Main_TurnoutControl.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Main_Window.shtml
+++ b/manual/JMRI_2-14_manual/Main_Window.shtml
@@ -17,7 +17,7 @@ DecoderPro&reg; Main Window
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/JMRI_2-14_manual/Main_XpressNet.shtml
+++ b/manual/JMRI_2-14_manual/Main_XpressNet.shtml
@@ -18,7 +18,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/JMRI_2-14_manual/Main_Zimo.shtml
+++ b/manual/JMRI_2-14_manual/Main_Zimo.shtml
@@ -18,7 +18,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/JMRI_2-14_manual/Main_acela.shtml
+++ b/manual/JMRI_2-14_manual/Main_acela.shtml
@@ -17,7 +17,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/JMRI_2-14_manual/Main_lightControl.shtml
+++ b/manual/JMRI_2-14_manual/Main_lightControl.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Tool Menu</h1>

--- a/manual/JMRI_2-14_manual/Main_wangrow.shtml
+++ b/manual/JMRI_2-14_manual/Main_wangrow.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/JMRI_2-14_manual/Multi_Decoder_Control.shtml
+++ b/manual/JMRI_2-14_manual/Multi_Decoder_Control.shtml
@@ -18,7 +18,7 @@ DecoderPro&reg; Main Window
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/JMRI_2-14_manual/Ops_AddCars.shtml
+++ b/manual/JMRI_2-14_manual/Ops_AddCars.shtml
@@ -15,7 +15,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Ops_AddEngine.shtml
+++ b/manual/JMRI_2-14_manual/Ops_AddEngine.shtml
@@ -15,7 +15,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Ops_AddInterchange.shtml
+++ b/manual/JMRI_2-14_manual/Ops_AddInterchange.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Ops_AddRoutes.shtml
+++ b/manual/JMRI_2-14_manual/Ops_AddRoutes.shtml
@@ -15,7 +15,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Ops_AddSiding.shtml
+++ b/manual/JMRI_2-14_manual/Ops_AddSiding.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Ops_AddStaging.shtml
+++ b/manual/JMRI_2-14_manual/Ops_AddStaging.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Ops_AddTrain.shtml
+++ b/manual/JMRI_2-14_manual/Ops_AddTrain.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Ops_AddYard.shtml
+++ b/manual/JMRI_2-14_manual/Ops_AddYard.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Ops_CarAttributes.shtml
+++ b/manual/JMRI_2-14_manual/Ops_CarAttributes.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Ops_Cars.shtml
+++ b/manual/JMRI_2-14_manual/Ops_Cars.shtml
@@ -15,7 +15,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Ops_EngineAttributes.shtml
+++ b/manual/JMRI_2-14_manual/Ops_EngineAttributes.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Ops_Engines.shtml
+++ b/manual/JMRI_2-14_manual/Ops_Engines.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Ops_ImportCarsFile.shtml
+++ b/manual/JMRI_2-14_manual/Ops_ImportCarsFile.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Ops_ImportEngines.shtml
+++ b/manual/JMRI_2-14_manual/Ops_ImportEngines.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Ops_Locations.shtml
+++ b/manual/JMRI_2-14_manual/Ops_Locations.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Ops_Locations_Modify_Trains.shtml
+++ b/manual/JMRI_2-14_manual/Ops_Locations_Modify_Trains.shtml
@@ -15,7 +15,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Ops_Locations_byCar.shtml
+++ b/manual/JMRI_2-14_manual/Ops_Locations_byCar.shtml
@@ -15,7 +15,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Ops_Locations_setCars.shtml
+++ b/manual/JMRI_2-14_manual/Ops_Locations_setCars.shtml
@@ -15,7 +15,7 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Ops_PrintOptions.shtml
+++ b/manual/JMRI_2-14_manual/Ops_PrintOptions.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Ops_Routes.shtml
+++ b/manual/JMRI_2-14_manual/Ops_Routes.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Ops_Settings.shtml
+++ b/manual/JMRI_2-14_manual/Ops_Settings.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Ops_Start.shtml
+++ b/manual/JMRI_2-14_manual/Ops_Start.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Ops_Trains.shtml
+++ b/manual/JMRI_2-14_manual/Ops_Trains.shtml
@@ -17,7 +17,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Using JMRI&reg; to Operate Trains</h1>

--- a/manual/JMRI_2-14_manual/Ops_TrainsModify.shtml
+++ b/manual/JMRI_2-14_manual/Ops_TrainsModify.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Using JMRI&reg; to Operate Trains</h1>

--- a/manual/JMRI_2-14_manual/Ops_Trains_BuildOptions.shtml
+++ b/manual/JMRI_2-14_manual/Ops_Trains_BuildOptions.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Ops_Trains_Timetable.shtml
+++ b/manual/JMRI_2-14_manual/Ops_Trains_Timetable.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Using JMRI&reg; to Operate Trains</h1>

--- a/manual/JMRI_2-14_manual/Ops_TripThruOperations.shtml
+++ b/manual/JMRI_2-14_manual/Ops_TripThruOperations.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Ops_schedule.shtml
+++ b/manual/JMRI_2-14_manual/Ops_schedule.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Using JMRI&reg; to Operate Trains</h1>

--- a/manual/JMRI_2-14_manual/Programmer_Multi_Decoder.shtml
+++ b/manual/JMRI_2-14_manual/Programmer_Multi_Decoder.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/JMRI_2-14_manual/Programmer_OpsMode.shtml
+++ b/manual/JMRI_2-14_manual/Programmer_OpsMode.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Programmer_ServiceMode.shtml
+++ b/manual/JMRI_2-14_manual/Programmer_ServiceMode.shtml
@@ -15,7 +15,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Programming Modes</h1>

--- a/manual/JMRI_2-14_manual/Programmer_Setup.shtml
+++ b/manual/JMRI_2-14_manual/Programmer_Setup.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>Using DecoderPro&reg;</h1>

--- a/manual/JMRI_2-14_manual/Programmer_SingleCV.shtml
+++ b/manual/JMRI_2-14_manual/Programmer_SingleCV.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Programmer_Start.shtml
+++ b/manual/JMRI_2-14_manual/Programmer_Start.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Simple_Programmer.shtml
+++ b/manual/JMRI_2-14_manual/Simple_Programmer.shtml
@@ -18,7 +18,7 @@ JMRI: Simple Programmer
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <h1>DecoderPro&reg; Main Window</h1>

--- a/manual/JMRI_2-14_manual/Start_DCC.shtml
+++ b/manual/JMRI_2-14_manual/Start_DCC.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Start_DCC_Hardware.shtml
+++ b/manual/JMRI_2-14_manual/Start_DCC_Hardware.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Start_DCC_Systems.shtml
+++ b/manual/JMRI_2-14_manual/Start_DCC_Systems.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Start_DecoderPro.shtml
+++ b/manual/JMRI_2-14_manual/Start_DecoderPro.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/manual/JMRI_2-14_manual/Start_Preferences.shtml
+++ b/manual/JMRI_2-14_manual/Start_Preferences.shtml
@@ -24,7 +24,7 @@ function MM_jumpMenu(targ,selObj,restore){ //v3.0
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 <h1>Getting Started with DecoderPro&reg;</h1>
 <h2>How do I set up my preferences?</h2>

--- a/manual/JMRI_2-14_manual/index.shtml
+++ b/manual/JMRI_2-14_manual/index.shtml
@@ -16,7 +16,7 @@
 <body>
 <!--#include virtual="/Header.shtml" -->
 
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>


### PR DESCRIPTION
See background in #345

Transforms .shtml files only with:
 - `Header" -->` to `Header.shtml" -->` (2 cases)
 - `Footer"-->` to `Footer.shtml" -->` (2 cases)
 - `Sidebar" -->` to `Sidebar.shtml" -->` (lots of cases)
