### PR TITLE
fix: java.net is dead, so don't link to it

### DIFF
--- a/index.shtml
+++ b/index.shtml
@@ -288,15 +288,15 @@ JMRI: A Java Model Railroad Interface
 		    </dd>
 	     </dl>
 	        
-		<h2><a href="https://www.java.net/dukeschoice/2006">JMRI wins Duke's Choice award from Sun Microsystems</a></h2>
+		<h2><a href="https://community.oracle.com/docs/DOC-922312">JMRI wins Duke's Choice award from Sun Microsystems</a></h2>
 		<dl>
 		    <dt class="im">
-			<a href="https://www.java.net/dukeschoice/2006"><img src="./images/06_duke_award/2006_dukes_choice_award_120.gif" width="105" height="105" alt="Dukes Choice"></a>
+			<a href="https://community.oracle.com/docs/DOC-922312"><img src="./images/06_duke_award/2006_dukes_choice_award_120.gif" width="105" height="105" alt="Dukes Choice"></a>
 		    </dt>
 		    <dd>
 		    	<a href="http://www.oracle.com/technetwork/java/index.html">Sun Microsystems</a> (now part of <a href="http://www.oracle.com/us/sun/index.html">Oracle</a>)
 		    	has awarded JMRI a 
-		    	<a href="https://www.java.net/dukeschoice/2006">2006 Duke's Choice award</a>.  
+		    	<a href="https://community.oracle.com/docs/DOC-922312">2006 Duke's Choice award</a>.  
 		    	Also called a "Dukie", this award is given
 			annually to "some of the most clever, practical, and inspirational Java technology applications on the planet".  
 			The award was presented at the

--- a/indexnew.shtml
+++ b/indexnew.shtml
@@ -288,15 +288,15 @@ JMRI: A Java Model Railroad Interface
 		    </dd>
 	     </dl>
 	        
-		<h2><a href="https://www.java.net/dukeschoice/2006">JMRI wins Duke's Choice award from Sun Microsystems</a></h2>
+		<h2><a href="https://community.oracle.com/docs/DOC-922312">JMRI wins Duke's Choice award from Sun Microsystems</a></h2>
 		<dl>
 		    <dt class="im">
-			<a href="https://www.java.net/dukeschoice/2006"><img src="./images/06_duke_award/2006_dukes_choice_award_120.gif" width="105" height="105" alt="Dukes Choice"></a>
+			<a href="https://community.oracle.com/docs/DOC-922312"><img src="./images/06_duke_award/2006_dukes_choice_award_120.gif" width="105" height="105" alt="Dukes Choice"></a>
 		    </dt>
 		    <dd>
 		    	<a href="http://www.oracle.com/technetwork/java/index.html">Sun Microsystems</a> (now part of <a href="http://www.oracle.com/us/sun/index.html">Oracle</a>)
 		    	has awarded JMRI a 
-		    	<a href="https://www.java.net/dukeschoice/2006">2006 Duke's Choice award</a>.  
+		    	<a href="https://community.oracle.com/docs/DOC-922312">2006 Duke's Choice award</a>.  
 		    	Also called a "Dukie", this award is given
 			annually to "some of the most clever, practical, and inspirational Java technology applications on the planet".  
 			The award was presented at the

--- a/install/USB.shtml
+++ b/install/USB.shtml
@@ -40,7 +40,7 @@ adapters, but hope that it will eventually be generally useful.
 Certain types of USB devices can be attached as a "HID device".
 (That stands for "Human Interface Device device", but let's not get distracted)
 The 
-<a href="https://jinput.dev.java.net">JInput project</a>
+<a href="https://jinput.github.io/jinput/">JInput project</a>
 has provided tools for accessing these devices which we can use
 to connect HID devices to events within the JMRI programs.
 


### PR DESCRIPTION
java.net is a long dead domain, so links to it are fixed.