### PR TITLE
Add smart footer links to GitHub page

### DIFF
--- a/Footer.shtml
+++ b/Footer.shtml
@@ -3,6 +3,24 @@
     <div id="footer">
 	<ul id="bn"></ul><!-- seems necessary to the formatting? -->
 
+    <!-- Add a link to Github history of file -->
+    <p>To see the history of this page and propose edits, please follow
+    <script>
+        var target = window.location.pathname;
+        target = (target.slice(-1) == "/") ? target+"index.shtml" : target;  // do default expansion of empty to index
+        
+        // check repository - only directories with files that include Footer.shtml
+        if (target.slice(0,6) == "/help/") {
+            target = "https://github.com/JMRI/JMRI/blob/master"+target;
+        } else if (target.slice(0,5) == "/xml/") {
+            target = "https://github.com/JMRI/JMRI/blob/master"+target;
+        } else { // must be in JMRI/website
+            target = "https://github.com/JMRI/website/blob/master"+target;
+        }
+        //document.write(target+" ")
+        document.write("<a href=\""+target+"\" title=\"File history on GitHub.com\">this link</a>.")
+    </script>
+    
 	<p>Thanks and congratulations to
 	   <a href="/help/en/Acknowledgements.shtml" title="Who is JMRI">
 	   	all who contributed</a>!</p>


### PR DESCRIPTION
This adds a link to the common footer that says:

> To see the history of this page and propose edits, please follow this link.

The link is created via Javascript, and goes to either the JMRI/JMRI or JMRI/website repository.  

Note this might not always work:  There could be automatically generated pages using the common footer that don't exist in the repositories.  But I haven't found any of those...

This is proposed as a solution to Issue #369 by @jerryg2003, comments welcome!