### PR TITLE
New email address

### DIFF
--- a/Copyright.html
+++ b/Copyright.html
@@ -56,7 +56,7 @@
       </h1>
 If you have any questions about the information on this page or what 
 it means to you, please 
-<a href="mailto:jmri@jmri.net">contact us</a>
+<a href="mailto:jmri@jmri.org">contact us</a>
 directly.
 
 <a name="trademarks"/>

--- a/donations.shtml
+++ b/donations.shtml
@@ -91,7 +91,7 @@ Thanks!
 
 <p>
 If you don't want to use PayPal, please 
-<a href="mailto:jmri@jmri.net">contact us directly via email</a>
+<a href="mailto:jmri@jmri.org">contact us directly via email</a>
 and we can make other arrangements.
 <!--#include virtual="/Footer.shtml" -->
 


### PR DESCRIPTION
jmri@jmri.net has been intermittent for unknown reasons, so switching the contact email to jmri@jmri.org