### PR TITLE
Fix main content scrolling

### DIFF
--- a/css/default.css
+++ b/css/default.css
@@ -626,16 +626,11 @@ hr {
 
 /*2 Column Layout on bigger screens */
 @media only screen and (min-width: 1025px) {
-	.mBody, #mainContent, #side {
-		position: absolute;
-	}
 	.mBody {
 		margin: 0 auto;
 	}
 	#mainContent {
-		width: 75%;
-		float: left;
-		left: 25%; /* = #mainContent is loaded before sidebar following guidelines (more important), so shift to right for width of #side(bar)*/
+		left: 250px; /* = #mainContent is loaded before sidebar following guidelines (more important), so shift to right for width of #side(bar)*/
 	}
 
 	/*.nomenu #mainContent, /* .nomenu @deprecated 4.21.3/Jan 2021 as it describes sidebar no menu = top */
@@ -647,9 +642,6 @@ hr {
 
 	#side {
 	    display: block;
-		width: 25%;
-		float: left;
-		left: -75%; /* = Width of #mainContent*/
 		animation: animate-left 0.4s;
 	}
 	#drop-nav, #show-side, #close-side {
@@ -665,7 +657,7 @@ hr {
 	width: 100%;
 	margin: 0 auto;
 	position: absolute;
-	top: 52px;
+	top: 64px;
 	left: 0;
 	padding: 0;
 }
@@ -685,7 +677,6 @@ hr {
 	voice-family: inherit;
     max-height: 100%;
     width: 250px;
-    position: fixed;
     z-index: 2;
     background-color: #F5F5DC; /*--background-color2: Sand Beige */
     color: #778899; /*var(--primary-color3); LightSlateGray */
@@ -901,15 +892,17 @@ hr {
 #mainContent {
 	background: White;
 	line-height: 1.3; /* value other than 'normal' needed for WinIE */
-    position: absolute;
-    top: 100px;
+    position: fixed;
+    top: 64px;
     z-index: -1;
 	margin-left: 10px;
 	margin-right: 10px;
 	padding: 20px 30px 0px 10px;
-    width: 100%;
+    max-width: 100%;
     float: left;
 	voice-family: inherit;
+	max-height: 100%;
+	overflow: auto;
 }
 
 .nomenu #mainContent,

--- a/css/default.css
+++ b/css/default.css
@@ -307,7 +307,7 @@
 	    padding: .2em .3em;
 	}
 	.since a:link {
-			color: Black
+			color: Black;
 			font-weight: normal;
 	}
 	.since a:visited {
@@ -702,7 +702,7 @@ hr {
 }
 #side h3, #side h3:link {
 	margin: 0.5em 0 0 0;
-	padding-left: 1em
+	padding-left: 1em;
 	background-color: inherit;
 	color: Black;
 }
@@ -848,6 +848,7 @@ hr {
 	top: 5px;
 	z-index: 4;
 }
+
 /* #searchform label {
 	font-size: 80%;
 	color: Black;
@@ -863,7 +864,7 @@ hr {
 	background: White;
 }
 #submit {
-	background-color: #778899; /*var(--primary-color3); LightSlateGray */
+	background-color: #778899; /*var(--primary-color3); LightSlateGray
 	color: Black;
 }
 #submit:hover, #submit:focus {
@@ -895,7 +896,7 @@ hr {
 	color: White;
 }
 
-}
+/* } */
 /*body*/
 #mainContent {
 	background: White;

--- a/css/default.css
+++ b/css/default.css
@@ -840,30 +840,6 @@ hr {
 	z-index: 4;
 }
 
-/* #searchform label {
-	font-size: 80%;
-	color: Black;
-}
-#q {
-	font-size: 70%;
-	font-weight: normal;
-	background: White;
-	color: Black;
-	padding: 2px;
-}
-#q:hover, #q:focus {
-	background: White;
-}
-#submit {
-	background-color: #778899; /*var(--primary-color3); LightSlateGray
-	color: Black;
-}
-#submit:hover, #submit:focus {
-	background-color: White;
-}
-*/
-/* End of search form, not used since 2020 */
-
 
 #title {
 	background: #AAC;


### PR DESCRIPTION
The mainContent scrolling included the space under the header bar.  The resulted in the jumps to anchors offset by the height of the header bar.

The first commit fixed 5 validation errors.  One of the errors effectively hid the CSS definition for mainContent.

The second commit changes the positioning of the mainContent to sit below the header bar and close to the side bar.  Scrolling was then enabled for mainContent. 

The media min-width: 1025px area was cleaned up to remove CSS that was being overridden by the mainContent and side definitions.  Note:  These come after the media statement and can override the media statement settings.