### PR TITLE
Fix links

### DIFF
--- a/install/qsidriver/index.html
+++ b/install/qsidriver/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 		<title>JMRI Hardware - QSI</title>
-		
+
 		<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
         <link rel="File-List" href="jmri_files/filelist.xml">
 
@@ -19,7 +19,6 @@ o\:*         { behavior: url(#default#VML) }
 <body bgcolor="#FFFFFF" text="#000000" alink="#000080">
 		<div align="center">
 
-			<img src="images/rule.gif" width="850" height="1" border="0">
                   <p align="center">
 			<b>
             Use QSI Quantum Programmer<br>
@@ -30,11 +29,11 @@ o\:*         { behavior: url(#default#VML) }
                 <tr>
                   <td width="300">
                   <p align="center"><font size="2" face="Arial">
-                  <a href="jmri/VCP_JMRIFv3.pdf" target="_empty">Download PDF version of 
+                  <a href="jmri/VCP_JMRIFv3.pdf" target="_empty">Download PDF version of
                   these Instructions</a></font><br>
                   <br>
                   <font face="Arial" size="2">
-                  <a href="https://www.silabs.com/Support%20Documents/Software/CP210x_VCP_Win2K_XP_S2K3.zip" target="_empty">Download SiLabs 
+                  <a href="https://www.silabs.com/Support%20Documents/Software/CP210x_VCP_Win2K_XP_S2K3.zip" target="_empty">Download SiLabs
                   VCP Drivers</a> </font>
                   <font face="Arial" size="1">
                   ver 5.3</font><font face="Arial" size="2"><br>
@@ -64,21 +63,21 @@ o\:*         { behavior: url(#default#VML) }
                 <tr>
                   <td width="100%" height="131">
                   The SiLabs
-                  Virtual Com Port Drivers (VCP) can be used with the QSI 
+                  Virtual Com Port Drivers (VCP) can be used with the QSI
                   Programmer so that the JMRI DecoderPro will recognize the Com
                   Port the Programmer is on. To accomplish this, the best
-                  method is to remove the SiLabs USBXpress Drivers required by 
-                  the QSI Solutions Programs and REPLACE them with the SiLabs 
+                  method is to remove the SiLabs USBXpress Drivers required by
+                  the QSI Solutions Programs and REPLACE them with the SiLabs
                   VCP Drivers entirely! <b>Warning</b>! Make sure you have the
                   latest versions of <br>
-                  Q1A and Q2 Upgrade Programs and the Quantum CV Manager 
+                  Q1A and Q2 Upgrade Programs and the Quantum CV Manager
                   Programs so you can use these with the VCP Drivers. These
-                  Programs will NOW work with both the SiLabs USBXpress USB 
+                  Programs will NOW work with both the SiLabs USBXpress USB
                   drivers and the SiLabs VCP drivers This means that you can
-                  replace the USB Drivers and now using one set of drivers for 
+                  replace the USB Drivers and now using one set of drivers for
                   BOTH QSI Program AND JMRI Programs. Use following steps to
-                  uninstall USBXpress Drivers, Reconfigure the VCP Drivers Setup 
-                  File, Install and Configure the VCP Drivers and Setup JMRI 
+                  uninstall USBXpress Drivers, Reconfigure the VCP Drivers Setup
+                  File, Install and Configure the VCP Drivers and Setup JMRI
                   DecoderPro and the QSI Programs for use with the QSI
                   Programmer.
                   </td>
@@ -87,16 +86,16 @@ o\:*         { behavior: url(#default#VML) }
                   <td width="100%" height="115" align="left">
                   <p class="MsoNormal" style="text-autospace: none">
                   <span style="font-size:10.0pt;font-family:Arial">1.) <u>
-                  Remove USBXpress Drivers for QSI Programmer</u>. Using the Add 
+                  Remove USBXpress Drivers for QSI Programmer</u>. Using the Add
                   / Remove Programs from Control Panel, remove any
-                  SiLabs USB drivers or USBXpress Drivers installed for the QSI 
-                  Programmer. If no drivers are present in the Control Panel, 
-                  but the QSI Programmer is still working, then Uninstall QSI 
+                  SiLabs USB drivers or USBXpress Drivers installed for the QSI
+                  Programmer. If no drivers are present in the Control Panel,
+                  but the QSI Programmer is still working, then Uninstall QSI
                   Programmer from Device Manager. To Open the Device Manager,
-                  right click on My Computer, choose Properties. Choose the 
-                  Hardware Tab. Then Click the Device Manager Button. (Also 
-                  available from the Control Panel, System Icon.)With the QSI 
-                  Programmer powered and connected with the USB cable, right 
+                  right click on My Computer, choose Properties. Choose the
+                  Hardware Tab. Then Click the Device Manager Button. (Also
+                  available from the Control Panel, System Icon.)With the QSI
+                  Programmer powered and connected with the USB cable, right
                   click and choose uninstall. Then unplug the QSI Programmer
                   USB cable.</span></td>
                 </tr>
@@ -132,7 +131,7 @@ src="jmri_files/image002.jpg" v:shapes="_x0000_s1058"><![endif]><br>
  <v:imagedata src="jmri_files/image003.png" o:title=""/>
 </v:shape><![endif]--><![if !vml]><img border=0 width=681 height=68
 src="jmri_files/image004.jpg" v:shapes="_x0000_s1057"><![endif]><br>
-                  </span><span style="font-size:10.0pt;font-family:Arial">Figure 
+                  </span><span style="font-size:10.0pt;font-family:Arial">Figure
                   1 - Add/Remove Programs<br>
 </span></td>
                 </tr>
@@ -177,7 +176,7 @@ src="jmri_files/image010.jpg" v:shapes="_x0000_s1061"><![endif]><br>
  <v:imagedata src="jmri_files/image011.png" o:title=""/>
 </v:shape><![endif]--><![if !vml]><img border=0 width=721 height=422
 src="jmri_files/image012.jpg" v:shapes="_x0000_s1062"><![endif]><br>
-                  </span><span style="font-size:10.0pt;font-family:Arial">Figure 
+                  </span><span style="font-size:10.0pt;font-family:Arial">Figure
                   5 - Device Manager with Programmer Removed<br>
 </span></td>
                 </tr>
@@ -189,7 +188,7 @@ src="jmri_files/image012.jpg" v:shapes="_x0000_s1062"><![endif]><br>
                   <a href="http://www.silabs.com/" style="text-decoration: underline; text-underline: single" target="_empty">
                   http://www.silabs.com</a><a href="http://www.silabs.com/" style="color: blue; text-decoration: underline; text-underline: single">
                   </a><br>
-                  From the CP210x_VCP_Win2K_XP_S2K3 folder run 
+                  From the CP210x_VCP_Win2K_XP_S2K3 folder run
                   CP210x_VCP_Win2K_XP_S2K3.exe using the default settings. Open
                   the SiLabs folder created by the install. Expand the MCU
                   folder, and then expand the CP210X folder. Click on the
@@ -206,23 +205,23 @@ src="jmri_files/image014.jpg" v:shapes="_x0000_s1063"><![endif]><br>
                 <tr>
                   <td width="100%" height="19">
                   <p class="MsoNormal" style="text-autospace: none; margin-left: .25in">
-                  <span style="font-size:10.0pt;font-family:Arial">Open this 
+                  <span style="font-size:10.0pt;font-family:Arial">Open this
                   file with notepad. This can be done by right clicking on the
                   file and choosing Open.<br>
-                  Using edit / find from the menu, you can type in the Find What 
+                  Using edit / find from the menu, you can type in the Find What
                   box: PID<br>
                   You will find 5 entries with the following: PID_EA60<br>
                   Change EA60 to 8208 on all five entries. All 5 instances
                   should now look like this: PID_8208<br>
-                  Be careful not to change or remove any other entries that PID 
+                  Be careful not to change or remove any other entries that PID
                   is part of.</span></p>
                   <p class="MsoNormal" style="text-autospace: none; margin-left: .25in" align="left">
-                  <span style="font-size:10.0pt;font-family:Arial">Click file, 
+                  <span style="font-size:10.0pt;font-family:Arial">Click file,
                   save on the open notepad. Close notepad. <br>
-                  This change will allow the VCP drivers to see the SiLabs Chip 
+                  This change will allow the VCP drivers to see the SiLabs Chip
                   inside of the Programmer.<br>
-                  (A copy of this file can be downloaded from the link above.. 
-                  If you use this file, replace the original slabvcp.inf with 
+                  (A copy of this file can be downloaded from the link above..
+                  If you use this file, replace the original slabvcp.inf with
                   this version)</span></p>
                   <p class="MsoNormal" style="text-autospace: none; margin-left: .25in" align="center">
                   <span style="font-size: 10.0pt; font-family: Arial"><!--[if gte vml 1]><v:shape
@@ -237,9 +236,9 @@ src="jmri_files/image016.jpg" v:shapes="_x0000_s1065"><![endif]></span><span sty
                   <span style="font-size:
 10.0pt;font-family:Arial">3.) Execute CP210xVCPInstaller.exe from the same
                   folder that slabvcp.inf is in. Use the default settings and
-                  click install from the CP210X USB to UART Bridge Driver 
+                  click install from the CP210X USB to UART Bridge Driver
                   install Window. Choose 'Continue Anyway' button, IF you get
-                  the Windows Driver Warning &quot;...has not passed the Hardware 
+                  the Windows Driver Warning &quot;...has not passed the Hardware
                   Compatibility Logo Testing&quot;.</span><p align="center">
                   <span style="font-size: 10.0pt; font-family: Arial"><!--[if gte vml 1]><v:shape
  id="_x0000_s1066" type="#_x0000_t75" style='width:542.25pt;height:311.25pt'>
@@ -264,8 +263,8 @@ src="jmri_files/image020.jpg" v:shapes="_x0000_s1067"><![endif]><br>
                   <td width="100%" height="19">
                   <span style="font-size: 10.0pt; font-family: Arial">4.)<span style="font:7.0pt 'Times New Roman';">
                   </span></span>
-                  <span style="font-size:10.0pt;font-family:Arial">The Virtual 
-                  Com Port will NOT show up in the device manager until you plug 
+                  <span style="font-size:10.0pt;font-family:Arial">The Virtual
+                  Com Port will NOT show up in the device manager until you plug
                   in the QSI Programmer and configure it to use the SiLabs VCP
                   Drivers.</span><p align="center">
                   <span style="font-size:10.0pt;font-family:Arial"><!--[if gte vml 1]><v:shape
@@ -285,7 +284,7 @@ src="jmri_files/image022.jpg" v:shapes="_x0000_s1068"><![endif]><br>
                   <p class="MsoNormal" style="text-indent: -13.5pt; text-autospace: none; margin-left: .25in; margin-right: -45.0pt; margin-top: 0in; margin-bottom: .0001pt" align="left">
                   <span style="font-size:
 10.0pt;font-family:Arial"></span><span style="font-size:10.0pt;font-family:Arial">The
-                  &quot;Found New Hardware Window&quot; should open, if you have 
+                  &quot;Found New Hardware Window&quot; should open, if you have
                   successfully removed all of the USBXpress Drivers.</span></p>
                   <p class="MsoNormal" style="text-indent: -13.5pt; text-autospace: none; margin-left: .25in; margin-right: -45.0pt; margin-top: 0in; margin-bottom: .0001pt" align="left">
                   <font size="2"><span style="font-family: Arial"></span></font><span style="font-size:10.0pt;font-family:Arial">Choose
@@ -304,13 +303,13 @@ src="jmri_files/image024.jpg" v:shapes="_x0000_s1089"><![endif]><br>
                 </tr>
                 <tr>
                   <td width="100%" height="19">
-                  <span style="font-size:10.0pt;font-family:Arial">Choose the 
-                  default &quot;Install Software Automatically&quot; (recommended) setting 
-                  and click Next. Choose Continue Anyway Button if you get the 
-                  Windows Driver Warning &quot;...has not passed the Hardware 
+                  <span style="font-size:10.0pt;font-family:Arial">Choose the
+                  default &quot;Install Software Automatically&quot; (recommended) setting
+                  and click Next. Choose Continue Anyway Button if you get the
+                  Windows Driver Warning &quot;...has not passed the Hardware
                   Compatibility Logo Testing&quot;. Drivers will finish installing.
                   Choose Finish when drivers are installed. You might get an
-                  information &quot;balloon&quot; from the notification area, by the clock 
+                  information &quot;balloon&quot; from the notification area, by the clock
                   that the Hardware is installed and ready to use.</span><p align="center">
                   <span style="font-size:10.0pt;font-family:Arial"><!--[if gte vml 1]><v:shape
  id="_x0000_s1071" type="#_x0000_t75" style='width:534pt;height:299.25pt'>
@@ -325,16 +324,16 @@ src="jmri_files/image026.jpg" v:shapes="_x0000_s1071"><![endif]><br>
  <v:imagedata src="jmri_files/image027.png" o:title=""/>
 </v:shape><![endif]--><![if !vml]><img border=0 width=718 height=399
 src="jmri_files/image028.jpg" v:shapes="_x0000_s1073"><![endif]><br>
-                  </span><span style="font-size:10.0pt;font-family:Arial">Figure 
+                  </span><span style="font-size:10.0pt;font-family:Arial">Figure
                   13 - Windows Logo Warning</span></td>
                 </tr>
                 <tr>
                   <td width="100%" height="19"><font face="Arial" size="2">5.)
-                  Open Device Manager and confirm that the SiLabs Virtual Com 
-                  Port is installed in the ports section. The driver will assume 
+                  Open Device Manager and confirm that the SiLabs Virtual Com
+                  Port is installed in the ports section. The driver will assume
                   the first available Com Port. (Normally 2 or 3) (On this test
-                  machine it found Port 8 as the first Available.) What Ever 
-                  port is found should show up in the Preferences Window of the 
+                  machine it found Port 8 as the first Available.) What Ever
+                  port is found should show up in the Preferences Window of the
                   JMRI DecoderPro.</font><p align="center">
                   <span style="font-size:10.0pt;font-family:Arial"><!--[if gte vml 1]><v:shape
  id="_x0000_s1076" type="#_x0000_t75" style='width:536.25pt;height:299.25pt'>
@@ -343,8 +342,8 @@ src="jmri_files/image028.jpg" v:shapes="_x0000_s1073"><![endif]><br>
 src="jmri_files/image030.jpg" v:shapes="_x0000_s1076"><![endif]><br>
                   Figure 14 - SiLabs Virtual Com Port (note port number)<br>
                   <br>
-                  (You can change the port by using the Advanced Button on the 
-                  Ports Tab available from the properties window of the VCP. 
+                  (You can change the port by using the Advanced Button on the
+                  Ports Tab available from the properties window of the VCP.
                   Make sure not to choose a Com Port already in use.) </span>
                   </p>
                   <p align="center">
@@ -389,7 +388,7 @@ src="jmri_files/image038.jpg" v:shapes="_x0000_s1080"><![endif]><br>
  <v:imagedata src="jmri_files/image039.png" o:title=""/>
 </v:shape><![endif]--><![if !vml]><img border=0 width=718 height=384
 src="jmri_files/image040.jpg" v:shapes="_x0000_s1081"><![endif]><br>
-                  </span><span style="font-size:10.0pt;font-family:Arial">Figure 
+                  </span><span style="font-size:10.0pt;font-family:Arial">Figure
                   19 - DecoderPro Preferences with QSI chosen</span></td>
                 </tr>
                 <tr>
@@ -444,7 +443,7 @@ src="jmri_files/image048.jpg" v:shapes="_x0000_s1087"><![endif]></span><span sty
                 <tr>
                   <td width="100%" height="19">
                   <p align="center"><font size="2" face="Arial">Figure 24 </font>
-                  <span style="font-size: 10.0pt; font-family: Arial">- Choose 
+                  <span style="font-size: 10.0pt; font-family: Arial">- Choose
                   Menu from Icon at top left corner</span></td>
                 </tr>
                 <tr>
@@ -455,7 +454,7 @@ src="jmri_files/image048.jpg" v:shapes="_x0000_s1087"><![endif]></span><span sty
                 <tr>
                   <td width="100%" height="19">
                   <p align="center"><font size="2" face="Arial">Figure 25 </font>
-                  <span style="font-size: 10.0pt; font-family: Arial">- After 
+                  <span style="font-size: 10.0pt; font-family: Arial">- After
                   clicking Quantum Programmer, choose option button<br>
                   and configure choice of VCP Driver and Port Number<br>
                   <![if !supportLineBreakNewLine]><br>
@@ -469,7 +468,7 @@ src="jmri_files/image048.jpg" v:shapes="_x0000_s1087"><![endif]></span><span sty
                 <tr>
                   <td width="100%" height="19">
                   <p align="center"><font size="2" face="Arial">Figure 26 </font>
-                  <span style="font-size: 10.0pt; font-family: Arial">- Choose 
+                  <span style="font-size: 10.0pt; font-family: Arial">- Choose
                   Command Station, Command Station Options then <br>
                   Choose Quantum Programmer Options</span></td>
                 </tr>
@@ -481,7 +480,7 @@ src="jmri_files/image048.jpg" v:shapes="_x0000_s1087"><![endif]></span><span sty
                 <tr>
                   <td width="100%" height="19">
                   <p align="center"><font size="2" face="Arial">Figure 27 </font>
-                  <span style="font-size: 10.0pt; font-family: Arial">- 
+                  <span style="font-size: 10.0pt; font-family: Arial">-
                   Configure Choice of Virtual Driver and Port Number</span></td>
                 </tr>
                 <tr>
@@ -489,8 +488,8 @@ src="jmri_files/image048.jpg" v:shapes="_x0000_s1087"><![endif]></span><span sty
                   <p class="MsoNormal" style="text-indent: -.25in; text-autospace: none; margin-left: .25in" align="left">
                   <b>
                   By using these Instructions and steps, YOU are accepting
-                  ALL responsibility for any damages and issues; use this 
-                  project at your own risk as these instructions come with no 
+                  ALL responsibility for any damages and issues; use this
+                  project at your own risk as these instructions come with no
                   warranty, express or implied. These instructions are limited
                   to adapting SiLabs VCP Drivers for use with the QSI Programmer. Suitability for use
                   with JMRI DecoderPro is neither Implied or guaranteed.
@@ -498,20 +497,20 @@ src="jmri_files/image048.jpg" v:shapes="_x0000_s1087"><![endif]></span><span sty
                   will work properly with this SiLabs VCP Adaptation. Contact
                   JMRI for issues and questions regarding DecoderPro.<br>
                   <br>
-                  My permission is given to include any or all of these steps 
+                  My permission is given to include any or all of these steps
                   and graphics for use on JMRI DecoderPro Instructions
-                  and/or Help Files and/or JMRI websites; for use on QSI/QSI 
-                  Solutions instructions and/or Help Files and/or QSI/QSI 
+                  and/or Help Files and/or JMRI websites; for use on QSI/QSI
+                  Solutions instructions and/or Help Files and/or QSI/QSI
                   websites. Additionally, you may download this
-                  article for your personal use and research. You may also make 
-                  copies and distribute them to other individuals providing that 
-                  the article is copied in its entirety, including the email 
+                  article for your personal use and research. You may also make
+                  copies and distribute them to other individuals providing that
+                  the article is copied in its entirety, including the email
                   address and site link, that no fee is charged, and this
                   notice remains intact. You may link to the web page this
-                  article is on or the Web Site, provided you do not incorporate 
-                  it in a frame or other method that would lead the average user 
-                  to believe that it is part of another Internet site. You may 
-                  not 'mirror' this article or this site without permission of 
+                  article is on or the Web Site, provided you do not incorporate
+                  it in a frame or other method that would lead the average user
+                  to believe that it is part of another Internet site. You may
+                  not 'mirror' this article or this site without permission of
                   the owner</b></p>
                   <p class="MsoNormal" style="text-indent: -.25in; text-autospace: none; margin-left: .25in">
                   <b>Contact Email:

--- a/releasenotes/jmri4.19.2.shtml
+++ b/releasenotes/jmri4.19.2.shtml
@@ -28,13 +28,13 @@
     <p>From: Bob Jacobsen</p>
     <p>Subject: Test Release 4.19.2 of JMRI/DecoderPro is available for download.</p>
 
-<!-- 
+<!--
 <p><b>This is a draft release note only; the download links do not yet work</b></p>
  -->
 
 <h2>Notes:</h2>
 
-<p>This is a test release.  Please 
+<p>This is a test release.  Please
 <a href="https://groups.io/g/jmriusers">post a note</a>
 if you encounter any new or old bugs!
 And please back up your JMRI files before installing this, in case you want to go
@@ -57,30 +57,30 @@ see our
 
 <a id="update" name="update"></a>
 <h3>Update From Older JMRI Versions</h3>
-<p>If you are currently using JMRI 4.11.9 or earlier, we strongly recommend that you update to 
-        <a href="jmri4.12.shtml">JMRI 4.12</a> and make sure that's running without errors 
-        during startup or on the JMRI log.  
-        Once you have JMRI 4.12 running OK, 
+<p>If you are currently using JMRI 4.11.9 or earlier, we strongly recommend that you update to
+        <a href="jmri4.12.shtml">JMRI 4.12</a> and make sure that's running without errors
+        during startup or on the JMRI log.
+        Once you have JMRI 4.12 running OK,
         store your configuration and panel files and use those from then on.
         There have been
-        changes in serial port support, panel file format and configuration options since those earlier releases, 
+        changes in serial port support, panel file format and configuration options since those earlier releases,
         and moving to the stable <a href="jmri4.12.shtml">JMRI 4.12</a> release
         is a good way to work through any possible problems.
         </p>
-<p>If you are currently using JMRI 4.7.3 or earlier on Linux or macOS (Windows doesn't need this), 
-        you <u>must</u> 
+<p>If you are currently using JMRI 4.7.3 or earlier on Linux or macOS (Windows doesn't need this),
+        you <u>must</u>
         update to <a href="jmri4.12.shtml">JMRI 4.12</a> and
         carrying out the <a href="jmri4.12.shtml#migration">migration process described in the JMRI 4.12 release note</a>
         before updating to this release.
 <p>If you are currently using JMRI 4.17.7 or earlier, including if the previous paragraphs
-        convinced you to update to JMRI 4.12, 
-        we strongly recommend that you update to 
-        <a href="jmri4.18.shtml">JMRI 4.18</a> and make sure that's running without errors 
+        convinced you to update to JMRI 4.12,
+        we strongly recommend that you update to
+        <a href="jmri4.18.shtml">JMRI 4.18</a> and make sure that's running without errors
         during startup or on the JMRI log.
-        Once you have JMRI 4.18 running OK, 
+        Once you have JMRI 4.18 running OK,
         store your configuration and panel files and use those from then on.
         There have been
-        changes panel file format and configuration options since earlier releases, 
+        changes panel file format and configuration options since earlier releases,
         and moving to the stable <a href="jmri4.18.shtml">JMRI 4.18</a> release
         is a good way to work through any possible problems.
         </p>
@@ -92,7 +92,7 @@ see our
     <li>None</li>
 </ul>
 <!--
-If any of those affect you, please either 
+If any of those affect you, please either
 wait for
 <a href="jmri4.11.3.shtml">JMRI 4.11.3</a>, due out shortly after this one,
 or (once there's a fix for the problem) pick up a
@@ -105,7 +105,7 @@ from
 <h3>New warnings for this release:</h3>
 
 <ul>
-   
+
     <li>The system names for Routes are required to start with "IO" to avoid
     	ambiguity or confusion with Reporters (the system names of which start
     	with "IR"). JMRI 4.19.2 or later should automatically rename Routes
@@ -151,21 +151,21 @@ These may be relevant to you if you're updating from an earlier version.
             <li>Raspberry PI using “PI"
             <li>TAMS using “TM”
         </ul>
-        you may have to migrate. Please update to JMRI 4.18 prior 
+        you may have to migrate. Please update to JMRI 4.18 prior
         to installing JMRI 4.19.1 (or later) and check the JMRI Console to
-        see if there are any instructions there. See the 
+        see if there are any instructions there. See the
         <a href="http://jmri.org/help/en/html/setup/MigrateSystemPrefixes.shtml">migration page</a>
         for additional information.
     </li>
 <li><span class="since">Since <a href="jmri4.19.1.shtml">JMRI 4.19.1</a></span>
-        The <code>getBeanByUserName</code> and <code>getBeanBySystemName</code> 
+        The <code>getBeanByUserName</code> and <code>getBeanBySystemName</code>
         calls in the various <code>Manager</code> classes
         are no longer needed with Java 8 and have been deprecated for eventual
-        removal.  Their replacements are 
-        <code>getByUserName</code> and <code>getBySystemName</code> 
-        respectively. 
-        If you use <code>getBeanByUserName</code> and <code>getBeanBySystemName</code> 
-        in script or Java code you've written, please 
+        removal.  Their replacements are
+        <code>getByUserName</code> and <code>getBySystemName</code>
+        respectively.
+        If you use <code>getBeanByUserName</code> and <code>getBeanBySystemName</code>
+        in script or Java code you've written, please
         switch to the new names.
     </li>
 
@@ -185,15 +185,15 @@ These may be relevant to you if you're updating from an earlier version.
         the final .dmg file is built, signed and notarized.  This was done to increase
         compatibility with macOS 10.15 Catalina.
         Please drag the JMRI icon to the Applications folder to install this release.
-        For more information on 
+        For more information on
         <a href="https://jmri.org/install/MacOSX.shtml#catalina">Catalina compatibility</a>,
-        see the 
+        see the
         <a href="https://jmri.org/install/MacOSX.shtml#catalina">JMRI web site</a>.
 
 <li><span class="since">Since <a href="jmri4.17.4.shtml">JMRI 4.17.4</a></span>
         Panel file NamedBean items such as Turnouts, Sensors, etc are now written to panel
         files in order by their Manager system prefix and system name.
-        Previously, they had (roughly) been written in the order they'd be 
+        Previously, they had (roughly) been written in the order they'd be
         read from the earlier file(s). This will result in a big change to the order
         the first time a file is re-written, but after that it should be much more stable.</li>
 
@@ -209,12 +209,12 @@ These may be relevant to you if you're updating from an earlier version.
     Pi-SPROG One with version 2.4 or earlier firmware will cause a timeout after a track short circuit. A dialog box will
     open to inform the user of this. The track power will be turned off and must be turned on again using the power control.
 
-</ul>   
+</ul>
 
 <a id="download" name="download"></a>
 <h2>Download links:</h2>
 
-Please note that the download links in this and future JMRI releases link to 
+Please note that the download links in this and future JMRI releases link to
 <a href="https://github.com/JMRI/JMRI/releases/">Github servers</a>.
 People are welcome to distribute the download files further via other websites, etc.
 If you want to check that you've received original, unmodified versions, please
@@ -234,7 +234,7 @@ check the files against the checksums shown below.
    sha256: c442ab5cb146d8acdcf35dcbe0df0ae93b3e25160c26cc0c0580fa23d3f3556c</li>
 </ul>
 
-<!-- 
+<!--
 Preliminary build files (not the final released files) can be found
 on the
 <a href="http://builds.jmri.org/jenkins/job/TestReleases/job/4.17.8/">CI project page</a>.
@@ -243,10 +243,10 @@ During development leading to the actual release, you can find test download fil
 <a href="http://builds.jmri.org/jenkins/job/Development/job/Packages/">continuous integration build page</a>.
 These are development files, and might not be working at any particular time.</p>
  -->
-  
+
 <a id="changes" name="changes"></a>
 <h2>Changes since <a href="jmri4.19.1.shtml">Test Release 4.19.1</a>:</h2>
- 
+
 The <a href="https://github.com/JMRI/JMRI/issues?utf8=✓&q=milestone%3A4.19.2+is%3Amerged">list of included commits</a> is available from our
 <a href="https://github.com/JMRI/JMRI">GitHub code repository</a>.
 
@@ -340,7 +340,7 @@ The <a href="https://github.com/JMRI/JMRI/issues?utf8=✓&q=milestone%3A4.19.2+i
 		    	to be updated.
 			    </li>
 			<li>Daniel Bergqvist provided information on
-			    <a href="http://jmri.org/help/en/html/doc/Technical/githubdesktopinto.shtml">how to use the GitHub Desktop tool</a>
+			    <a href="http://jmri.org/help/en/html/doc/Technical/githubdesktopintro.shtml">how to use the GitHub Desktop tool</a>
 			    for JMRI development.
 			<li>Updated the JDOM library from 2.0.5 to 2.0.6. Removed the unused JDOM 1 support.</li>
         </ul>

--- a/releasenotes/jmri4.20.shtml
+++ b/releasenotes/jmri4.20.shtml
@@ -26,7 +26,7 @@
     <p>From: Bob Jacobsen</p>
     <p>Subject: Production Release 4.20 of JMRI/DecoderPro is available for download.</p>
 
-<!-- 
+<!--
 <p><b>This is a draft release note only; the download links do not yet work</b></p>
  -->
 
@@ -49,28 +49,28 @@ see our
 If you are currently using a version older than JMRI 4.18, please follow these instructions carefully:
 
 <ol>
-<li>Is your current version older than <a href="jmri4.12.shtml">JMRI 4.12</a>? 
+<li>Is your current version older than <a href="jmri4.12.shtml">JMRI 4.12</a>?
     If so, then update to <a href="jmri4.12.shtml">JMRI 4.12</a> first, and ensure everything works correctly: check
     start-up, check things you need to be working, and check the JMRI log as well.
-    Once all is well, store your configuration and panel files under a new name and use those from now on. 
+    Once all is well, store your configuration and panel files under a new name and use those from now on.
     Continue with step 2.
     <p>
-    If you are currently using JMRI 4.7.3 or earlier on Linux or macOS (Windows doesn't need this), 
-    then it's <u>very important</u> 
+    If you are currently using JMRI 4.7.3 or earlier on Linux or macOS (Windows doesn't need this),
+    then it's <u>very important</u>
     that you update to <a href="jmri4.12.shtml">JMRI 4.12</a> and
     carrying out the <a href="jmri4.12.shtml#migration">migration process described in the JMRI 4.12 release note</a>
     before updating to any later relese.
     </li>
-    
-<li>Is your current version older than <a href="jmri4.18.shtml">JMRI 4.18</a>? 
+
+<li>Is your current version older than <a href="jmri4.18.shtml">JMRI 4.18</a>?
     Then update to <a href="jmri4.18.shtml">JMRI 4.18</a> first, and ensure that works correctly: check
     start-up, check things you need to be working, and check the JMRI log as well.
-    Once all is well, store your configuration and panel files under a new name and use those from now on. 
+    Once all is well, store your configuration and panel files under a new name and use those from now on.
 
-<li>You can then install this release. 
-</ol>   
- 
-Following this multi-step order of updating via stable major releases safeguards you against possible migration issues 
+<li>You can then install this release.
+</ol>
+
+Following this multi-step order of updating via stable major releases safeguards you against possible migration issues
 that can arise from skipping these versions.
 
 <a id="problems" name="problems"></a>
@@ -80,7 +80,7 @@ that can arise from skipping these versions.
      a bug and has been fixed in 4.21.1.</li>
    </ul>
    <!--
-If any of those affect you, please either 
+If any of those affect you, please either
 wait for
 <a href="jmri4.17.2.shtml">JMRI 4.17.2</a>, due out shortly after this one,
 or (once there's a fix for the problem) pick up a
@@ -108,18 +108,18 @@ from
         the final .dmg file is built, signed and notarized.  This was done to increase
         compatibility with macOS 10.15 Catalina.
         Please drag the JMRI icon to the Applications folder to install this release.
-        For more information on 
+        For more information on
         <a href="https://jmri.org/install/MacOSX.shtml#catalina">Catalina compatibility</a>,
-        see the 
+        see the
         <a href="https://jmri.org/install/MacOSX.shtml#catalina">JMRI web site</a>.
 
 <li><span class="since">Since <a href="jmri4.17.4.shtml">JMRI 4.17.4</a></span>
         Panel file NamedBean items such as Turnouts, Sensors, etc are now written to panel
         files in order by their Manager system prefix and system name.
-        Previously, they had (roughly) been written in the order they'd be 
+        Previously, they had (roughly) been written in the order they'd be
         read from the earlier file(s). This will result in a big change to the order
         the first time a file is re-written, but after that it should be much more stable.</li>
-        
+
 </ul>
 
 <h3>Older warnings</h3>
@@ -141,14 +141,14 @@ These may be relevant to you if you're updating from an earlier version.
 <li><span class="since">Since <a href="jmri4.15.6.shtml">JMRI 4.15.6</a></span>
         Starting in <a href="jmri4.15.6.shtml">JMRI 4.15.6</a>, Memories
         must have valid system names of the form "IM" folllowed by something.
-        "IM123" and "IMEAST" are both valid. 
-        The system name "IM", all by itself, has never been valid, but JMRI 
+        "IM123" and "IMEAST" are both valid.
+        The system name "IM", all by itself, has never been valid, but JMRI
         will now be enforcing that:
         <ul>
             <li>You won't be able to create a memory with that name via
                 the Memory table or scripts
-            <li>If you have that name in a panel file, an error will be 
-                logged and the panel file won't load. You'll have to 
+            <li>If you have that name in a panel file, an error will be
+                logged and the panel file won't load. You'll have to
                 remove it from he file or rename it in the file
                 before loading it.
         </ul>
@@ -166,11 +166,11 @@ These may be relevant to you if you're updating from an earlier version.
             <li>But note you can no longer refer to "ITSOME LOWER CASE NAME" or
                 "ITSome LoWeR cAse Name" and get the same one.
         </ul>
-        This should not require any migration for stored configurations or 
-        panel files, as they have been automatically been being kept consistent 
+        This should not require any migration for stored configurations or
+        panel files, as they have been automatically been being kept consistent
         since JMRI 4.8.  But you might have case errors in i.e. scripts which
         will fixing inconsistent references in your scripts.
-        Of course, bugs are always possible. If you find a place where 
+        Of course, bugs are always possible. If you find a place where
         names seem to be handled inconsistently, please let us know!
 
 <li><span class="since">Since <a href="jmri4.15.4.shtml">JMRI 4.15.4</a></span>
@@ -211,16 +211,16 @@ These may be relevant to you if you're updating from an earlier version.
     open to inform the user of this. The track power will be turned off and must be turned on again using the power control.
 
 </ul>
-      
+
 <a id="download" name="download"></a>
 <h2>Download links:</h2>
 
-Please note that the download links in this and future JMRI releases link to 
+Please note that the download links in this and future JMRI releases link to
 <a href="https://github.com/JMRI/JMRI/releases/">Github servers</a>.
 People are welcome to distribute the download files further via other websites, etc.
 If you want to check that you've received original, unmodified versions, please
 check the files against the checksums shown below.
- 
+
 <ul>
 <li>OS X / macOS: <a
 	href="https://github.com/JMRI/JMRI/releases/download/v4.20/JMRI.4.20+Rc7ba8249b.dmg">https://github.com/JMRI/JMRI/releases/download/v4.20/JMRI.4.20+Rc7ba8249b.dmg</a><br/>
@@ -235,13 +235,13 @@ check the files against the checksums shown below.
    sha256: f4019e3fa65801e7732ce99684d9fd8a05ba1bc47a17352e9fc3944bb6e8b68b</li>
 </ul>
 
-<!-- 
+<!--
 Preliminary build files (not the final released files) can be found
 on the
 <a href="http://builds.jmri.org/jenkins/job/TestReleases/job/4.20/">CI project page</a>.
  -->
 
-<!-- 
+<!--
 During development leading to the actual release, you can find test download files on the
 <a href="http://builds.jmri.org/jenkins/job/Development/job/Packages/">continuous integration build page</a>.
 These are development files, and might not be working at any particular time.</p>
@@ -251,9 +251,9 @@ These are development files, and might not be working at any particular time.</p
 <h2>Changes since <a href="jmri4.16.shtml">production release 4.18</a>:</h2>
 
 <p>
-This production version is made from test releases 4.19.1 through 4.19.9.  The 
+This production version is made from test releases 4.19.1 through 4.19.9.  The
 <a href="https://github.com/JMRI/JMRI/pulls?utf8=✓&q=is%3Apr+merged%3A%3E%3D2019-07-05">full list of changes</a>
-in those is 
+in those is
 <a href="https://github.com/JMRI/JMRI/pulls?utf8=✓&q=is%3Apr+merged%3A%3E%3D2019-07-05">available from our code repository</a>.
 
 
@@ -346,7 +346,7 @@ in those is
         <h4>SoundTraxx</h4>
             <ul>
                 <li>DSD-100LC steam & diesel add CV59</li>
-                <li>Marc Fournier added 
+                <li>Marc Fournier added
                     the Alco PA-PB and F7A-B to the
                     SoundTraxx SndVal Diesel Walthers Mainline
                     decoder definition.
@@ -357,7 +357,7 @@ in those is
         <a id="CPE" name="CPE"></a>
         <ul>
             <li>The <strong>Palette</strong> and <strong>Circuit Builder</strong>
-             windows make a "best effort" to open at a position minimizing 
+             windows make a "best effort" to open at a position minimizing
              any area that may obscure the panel display.</li>
         <h4>Circuit Builder</h4>
             <a id="CPE-CB" name="CPE-CB"></a>
@@ -371,8 +371,8 @@ in those is
             <a id="CPE-P" name="CPE-P"></a>
             <ul>
             <li>Each tab resizes to display itself with its preferred dimensions.</li>
-            <li>The <strong>Memory</strong> Tab has been modified to display generic 
-             forms of their respective devices.  Dragging is best accomplished by 
+            <li>The <strong>Memory</strong> Tab has been modified to display generic
+             forms of their respective devices.  Dragging is best accomplished by
              mouse down within the <strong>Drag to Panel</strong> box, but outside
              of the device icon itself.</li>
             <li>Bugs in the <strong>Signal Mast</strong> and <strong>Background</strong>
@@ -409,7 +409,7 @@ in those is
         <ul>
 	        <li>George Warner added "Align to grid" options</li>
 	        <li>George Warner added the ability to rotate the Layout Editor display</li>
-            <li>Improved the output when 
+            <li>Improved the output when
                 <a href="https://www.jmri.org/help/en/html/apps/PanelPro/ShowPanel.shtml">displaying the contents of a panel file</a>
                 in a web browser.</li>
             <li>Restore ability to type in new Block name in toolbar panel </li>
@@ -422,7 +422,7 @@ in those is
 	            so that new features can be added more reliably. Please
 	            keep an eye out for any new issues!
 	            <p>
-	            Note that files written by 4.19.6 may not be readable 
+	            Note that files written by 4.19.6 may not be readable
 	            by JMRI 4.19.5 and before.
 	        </li>
             <li>
@@ -432,7 +432,7 @@ in those is
                 <code>jmri.jmrit.display.EditorManager</code> in scripts instead.
             </li>
             <li>
-                George Warner added the ability to assign a block 
+                George Warner added the ability to assign a block
                 to a turntable to represent the track on the turntable bridge.
                 You enter the block from the Edit pane in the turntable's popup menu.</li>
         </ul>
@@ -476,7 +476,7 @@ in those is
    <h3>Panel Editors</h3>
         <a id="PE" name="PE"></a>
         <ul>
-            <li>Improved the output when 
+            <li>Improved the output when
                 <a href="https://www.jmri.org/help/en/html/apps/PanelPro/ShowPanel.shtml">displaying the contents of a panel file</a>
                 in a web browser.</li>
         </ul>
@@ -484,7 +484,7 @@ in those is
     <h3>Resources</h3>
         <a id="Resources" name="Resources"></a>
         <ul>
-            <li>Konrad Malkowski added icons for 
+            <li>Konrad Malkowski added icons for
                 <a href="http://jmri.org/resources/icons/panels/DominoPanel">European domino-style</a>
                 panels.
             <li>Added several missing index pages to the resource
@@ -533,7 +533,7 @@ in those is
                 instance of a manager have been removed. Use
                 <code>InstanceManager.getDefault(NameOfManager.class)</code>
                 instead.</li>
-            <li><a href="https://github.com/JMRI/JMRI/pull/8286">PR 8286</a> revised the way 
+            <li><a href="https://github.com/JMRI/JMRI/pull/8286">PR 8286</a> revised the way
                 that JMRI code should fire and catch events.  If you have code (Java or script)
                 of your own that implements event firing or tricky listening, you
                 should review those changes to see if they will or should affect your code.</li>
@@ -546,18 +546,18 @@ in those is
             </li>
     		<li>If you have a script that uses the AbstractShutDownTask class, you
     			need to rename the "execute()" routine to "run()", and change the
-    			return statement from "return True" to just "return"               
+    			return statement from "return True" to just "return"
             <li>The jython/AC_PowerControl.py,
                     jython/AutoDispatcher2.py,
                     jython/IoT/JMRI_TcpPeripheral.py,
                     jython/ShutDownExample.py, and
-                    jython/TurnoutStatePersistence.py    
+                    jython/TurnoutStatePersistence.py
                     scripts have been updated to handle the change
                     listed just above.  If you have your own version of these
                     scripts, you should either copy the distributed ones
-                    or update your own.          
+                    or update your own.
 		</ul>
-		
+
     <h3>Signals</h3>
         <a id="Signals" name="Signals"></a>
 	    <h4>Cab Signals</h4>
@@ -574,15 +574,15 @@ in those is
                     are validated.  Unfortunately, some files are already inconsistent.
                     Fixed a number of files with invisible appearance definitions
                     by duplicating the appearance file (i.e. adding a -b version with
-                    the different appearances).  Temporarily commented out 
-                    some of the 
+                    the different appearances).  Temporarily commented out
+                    some of the
                     <a href="http://jmri.org/xml/schema/appearancetable.xsd">schema checks</a>
                     until the existing files can be resolved.
                     </li>
-                <li>Bob Milhaupt and Greg McCarthy updated the 
+                <li>Bob Milhaupt and Greg McCarthy updated the
                     B&O semaphore,
                     NW-1981,
-                    SOU-1981 and 
+                    SOU-1981 and
                     WM-1980 signal systems to correct some internal inconsistencies.
                     </li>
                <li>Eckart Meyer updated the DB HV 1969 system to have proper aspect control.</li>
@@ -608,7 +608,7 @@ in those is
                 <li>F to switch to the "Functions" section
                 <li>C to switch to the "Control" section which sets speed
             </ul>
-                This is in addition to left arrow and right arrow, which 
+                This is in addition to left arrow and right arrow, which
                 move from one throttle to the next if you have more than one open.
                 Please note that this act when the key is released.
             </li>
@@ -701,14 +701,14 @@ in those is
         <ul>
             <li>The JMRI Demo shortcut has been removed from Windows installs</li>
             <li>
-                The <code>getBeanByUserName</code> and <code>getBeanBySystemName</code> 
+                The <code>getBeanByUserName</code> and <code>getBeanBySystemName</code>
                 calls in the various <code>Manager</code> classes
                 are no longer needed with Java 8 and have been deprecated for eventual
-                removal.  Their replacements are 
-                <code>getByUserName</code> and <code>getBySystemName</code> 
-                respectively. 
-                If you use <code>getBeanByUserName</code> and <code>getBeanBySystemName</code> 
-                in script or Java code you've written, please 
+                removal.  Their replacements are
+                <code>getByUserName</code> and <code>getBySystemName</code>
+                respectively.
+                If you use <code>getBeanByUserName</code> and <code>getBeanBySystemName</code>
+                in script or Java code you've written, please
                 switch to the new names.
             </li>
             <li>Petr Sidlo added a Pragotron clock, which is digital clock
@@ -730,7 +730,7 @@ in those is
 		    	to be updated.
 			    </li>
 			<li>Daniel Bergqvist provided information on
-			    <a href="http://jmri.org/help/en/html/doc/Technical/githubdesktopinto.shtml">how to use the GitHub Desktop tool</a>
+			    <a href="http://jmri.org/help/en/html/doc/Technical/githubdesktopintro.shtml">how to use the GitHub Desktop tool</a>
 			    for JMRI development.
 			<li>Updated the JDOM library from 2.0.5 to 2.0.6. Removed the unused JDOM 1 support.</li>
             <li>Added a feature which lets you set the height of rows
@@ -739,7 +739,7 @@ in those is
                 so that signal icons can be made fully visible.</li>
             <li>Lots of updates to the organization of the web site so that the sidebars
                 provide better navigation.</li>
-            <li><code>Manager.getSystemNameArray()</code> has been removed after being 
+            <li><code>Manager.getSystemNameArray()</code> has been removed after being
                 deprecated for two years. Please migrate to using
                 <code>Manager.getNamedBeanSet()</code> instead.  If you really
                 must have an array, use <code>Manager.getNamedBeanSet().toArray()</code>;
@@ -754,13 +754,13 @@ in those is
                 should manually add smtp.jar from <a href="https://javaee.github.io/javamail/">JavaMail</a>
                 to the JMRI classpath
                 (see <a href="/help/en/html/doc/Technical/StartUpScripts.shtml">Startup Scripts</a>)
-            <li>Windows Installer updated to support OpenJDK 8 from <a 
+            <li>Windows Installer updated to support OpenJDK 8 from <a
                 href="https://adoptopenjdk.net">AdoptOpenJDK.net</a>.</li>
-            <li>Andrew Crosland fixed some nasty flickering in the Nixie clock and 
+            <li>Andrew Crosland fixed some nasty flickering in the Nixie clock and
             	ammeter frames.</li>
         </ul>
 
-<!-- Older notes above, for merging above -->       
+<!-- Older notes above, for merging above -->
 
    <!--#include virtual="/Footer.shtml" -->
   </div><!-- closes #mainContent-->

--- a/releasenotes/jmri4.25.2.shtml
+++ b/releasenotes/jmri4.25.2.shtml
@@ -225,7 +225,7 @@ The <a href="https://github.com/JMRI/JMRI/issues?utf8=✓&q=milestone%3A4.25.2+i
             messages are seen for user-selected LocoNet turnout addresses.  This
             may be useful when the Digitrax command station "Bushby" feature is
             enabled.  More technical discussion of the issues associated with the
-            Bushby feature may be found in the discussion of <a href="../html/hardware/loconet/Digitrax.shtml#alternatives">
+            Bushby feature may be found in the discussion of <a href="/help/en/html/hardware/loconet/Digitrax.shtml#alternatives">
             Command Station Turnout Command
             Rejection Avoidance Strategies</a> in the general Digitrax help page.</li>
 


### PR DESCRIPTION
Additional items found when running against the jmri.org web site.

Note:  The 2-12, 3-0, 3-2, 3-4, and 3-6 manual issues are being ignored.  As far as I can tell, these are not reachable from  jmri.org.  The 2-14 manuals will be reformatted, updated to HTML 5 and have the link issues resolved.