### PR TITLE
Web search results color fix

### DIFF
--- a/css/default.css
+++ b/css/default.css
@@ -954,7 +954,7 @@ hr {
 .list dd {
 	margin: 0 0 0 2em; /*mobile first */
 	padding: 1px 0 0.4em 0.7em;
-	border-bottom: solid 1px LightSlateGrey;
+	border-bottom: solid 1px LightSlateGray;
 }
 .list dd p, .list dd ul {
 	margin-top: 0.2em;


### PR DESCRIPTION
Makes the title of search results visible, using css2021 colors. Fixes Issue JMRI/JMRI #11053