### PR TITLE
Update Linux Install page

### DIFF
--- a/install/Linux.shtml
+++ b/install/Linux.shtml
@@ -16,177 +16,219 @@
 <!--#include virtual="Sidebar.shtml" -->
   <div id="mainContent">
 
+    <p class="noted">This page has been updated for JMRI 5 and Java 11.  For the original
+    version that includes information back to JMRI 2, see the <a href="LinuxOld.shtml">original page</a>.
+    Be aware that much of the information is obsolete.</p>
+
   <h1>JMRI Install Guide: Linux</h1>
-		<ul class="snav"><!-- TOC -->
-		<li><a href="#installation">Installation</a>
-		<li><a href="#startup">Starting JMRI</a>
-		<li><a href="#notes">Notes</a>
-		</ul>
 
-      This page describes general aspects of installing JMRI on Linux.
+    <p>There are multiple versions of Linux, all slightly different and requiring installation
+    instructions that differ in detail.  There are specific pages describing details of installation
+    for the following distributions.</p>
 
-      <p>
-      There are multiple versions of Linux, all slightly different and
-      requiring installation instructions that differ in detail.
-      There are specific pages describing details of
-      installation on
-				<ul>
-				<li><a href="Mint20.shtml">Mint 20</a> (no command line use)
-				<li><a href="Ubuntu.shtml">Ubuntu</a>
-				<li><a href="decTop.shtml">Xubuntu</a> (on a decTOP small computer)
-				<li><a href="OpenSUSE.shtml">Open SUSE</a>
-				<li><a href="Mint.shtml">Mint</a>
-				</ul>
+    <ul>
+      <li><a href="Mint20.shtml">Mint 20</a> (no command line use)</li>
+    </ul>
 
-			There are also detailed instructions for installing on a
-				<ul>
-				<li><a href="Raspbian.shtml">Raspberry Pi</a></li>
-				<li><a href="EeePC.shtml">EeePC</a></li>
-				<li><a href="OLPC_XO.shtml">OLPC (One Laptop Per Child) XO</a></li>
-				</ul>
+    <p>Some Linux distributions have associated repositories that make it easier to install software.</p>
+    <ul>
+      <li><a href="https://slackbuilds.org/apps/jmri/">Slackware</a></li>
+    </ul>
 
-	        Some Linux distributions have associated repositories that make it easier to
-	        install software.  If you have one of those, you can find more info at:
-	            <ul>
-	            <li><a href="https://slackbuilds.org/apps/jmri/">Slackware</a>
-	            </ul>
-			<p>
-            The general procedure to install JMRI is:</p>
+    <h2>General JMRI Linux Install Procedure</h2>
 
-            <ol>
-				<li>Determine if your hardware supports Java and JMRI<br>
-                <br>
-				<a name="sysreq"></a><strong>JMRI System Requirements</strong><br>
-				Using JMRI requires a combination of hardware (in this case running Linux), Java software and a JMRI
-                download for a specific version.
-                <ul>
-                    <li>JMRI&reg; version 5.x requires Java 11</li>
-                    <li>Version 4.2 requires Java 1.8</li>
-                    <li>Version 3.10.1 requires Java 1.6 or later</li>
-                    <li>Version 2.14.1 requires Java 1.5 (or 1.6 if you wish for drag &amp; drop)</li>
-                    <li>Version 2.12 requires Java 1.5 or later</li>
-				</ul>
+    <p>The following steps provide general instructions for installing JMRI on Linux using the
+    terminal command line along with brief GUI descriptions for some activities. It should work for
+    most Debian and Red Hat based distributions.It has been tested on Mint 20.3, Ubuntu 22.04,
+    Raspberry Pi OS and CentOS 9.  The serial connectons have been tested using the RR-CirKits
+    <em>LCC Buffer-USB</em>.</p>
 
-                <br>These steps outline how to install DecoderPro on Linux.
-				They should work for Red Hat 8, 9 and 10. They don't
-				work on RedHat 7.<br>
+    <p>Note: The instructions use the standard tilde (~) shortcut to represent the users's home
+    directory at <strong><em>/home/&lt;username&gt;</em></strong>.
 
-				(For other versions of Linux, please
-				see the first item in our
-				<a href="FAQLinux.html">JMRI Linux FAQ</a>).<br>
+    <h3>Install Java 11</h3>
 
-				You'll need the correct serial port or USB port
-				to attach to your layout hardware.  JMRI is compatible
-				with USB-to-Serial adapters, so long as they have
-				Linux drivers that make them look like regular serial ports.
-				For troubleshooting, see the
-				<a href="FAQLinux.html#usb">FAQ</a><br>
-                <br>
-                </li>
+    <p>Starting with JMRI 5.0, Java 11 is required.  See <a href="../java/index.shtml#linux_java">
+    Install Java 11</a>.</p>
 
-				<li>Get and Install Java (if needed)<br>
+    <h3>Serial Port Access</h3>
 
-				To see if you have a version of Java already installed, in Terminal enter:<br>
-				<code> sh> java -version</code>
-                <br>
-				If the Java version is 1.8 or later, you may be fine, but
-                be aware that if you did not install Java on your system
-                yourself, some systems have Java only partially installed. They
-                will respond correctly to the above command, but still are not
-                all there. If your system does not have Java in the environment
-                variable PATH, the install is probably not complete. Check with
-                the system manager or do a fresh Java installation.<br>
+    <p>The majority of JMRI layout connections are based on serial ports.  On recent hardware these
+    are implemented using USB ports and a USB device such as the RR-CirKits <em>LCC Buffer-USB</em>.
+    Most USB serial devices do not require the installation of drivers.  The Linux user running JMRI
+    needs to have <strong>read/write</strong> access to the serial ports. The following command
+    updates the user's group list with access to the serial ports.</p>
 
-				If it is not at least 1.8, or if you get a "java: not found"
-				error, you will need to install it.<br>
-                <br>
-				Most Linux distributions can get an automated install download
-				from Oracle by clicking on this button:<br>
-				<a href="http://www.java.com" target="_blank">
-				<img src="https://download.oracle.com/technetwork/java/get-java/getjavasoftware-88x31.png" alt="Get Java Software" />
-				</a>
-                <br>
-				If that doesn't work or you need to manually install Java,
-				you can find further information on the
-				<a href="http://www.oracle.com/technetwork/java/javase/downloads/index.html"> Oracle Java downloads page</a>.
-				    <ul>
-				    <li>Java comes in several forms:
-				    JMRI needs the Standard Edition (SE) version, but
-				    Java EE is also OK;<br>
-				    neither Java ME or Java Embedded are sufficient.
-				    <li>There are also different Java SE installers: JMRI can
-				    run with either a proper SDK (Software Development Kit, for compiling and running Java)
-				    or JRE (Java Runtime Environment, for just running Java) installation.
-				    <li>
-				    Note: JMRI up to 4.99 was developed with Java 1.8. It should work fine with later versions (Java
-                    1.9, Java 10, 11, etc)
-	                but you may get a message about "WARNING: An illegal reflective access operation has occurred" and
-                    "WARNING: Please consider reporting this to the maintainers".
-	                We know about this; you can ignore the messages.
-				    </ul>
-                </li>
+    <code>sudo usermod -a -G dialout ${USER}</code>
 
+    <p>Do not change ${USER}.  That is a variable that contains the current user name.</p>
 
-				<li>Give user-level application access to serial ports<br>
-				    <code>chmod 666 /dev/ttyS0</code><br>
-				    <code>chmod 666 /dev/ttyS1</code>
-				    </li>
-				<li>
-				   Give user access to lock files (required on Red Hat).
-				   Edit <code>/etc/group</code> &amp; <code>/etc/gshadow</code> to add 'user' to the 'uucp' and 'lock'
-				   groups.</li>
+    <h3>Download JMRI</h3>
 
-				<li>Get JMRI
-				    <a href="../download/index.shtml#prod-rel">Download</a> a version of JMRI, either the
-				    latest production version, or a "test version".  Since the version
-				    numbers change with every release, this link takes you to the general
-				    JMRI download page, where you can select whichever version you like.<br>
+    <p>The JRMI Linux install package is a tar gzip file, <strong>tgz</strong>.  Click on
+    <a href="../download/index.shtml#prod-rel">Download</a>.  This will redirect the browser to the
+    latest production download page.  Click on the link for the Linux file.  If a different version,
+    such as a test release, is desired, use the links in the sidebar to select the release note for
+    that version.</p>
 
-				    The JMRI project is continuously adding features, bug fixes,
-				    examples and tutorials to the release, and so a new "test" versions
-				    appear every couple of weeks.  You may find one of these has features
-				    that you really want.  These are announced in the "JMRI users" Groups.io
-				    discussion group at
-				    <a
-				     href="https://groups.io/g/jmriusers">https://groups.io/g/jmriusers</a>.<br>
-                    <br>
-                </li>
+    <p>While at the download page, it is good idea to read the release note about the changes and
+    any warnings.</p>
 
-				<li><a id="update"></a>Install JMRI<br>
-				    Uncompress/untar the file you downloaded above.  This will create a new "JMRI" folder.<br>
-				    Note: Each JMRI release is an independent set of files: It's intended to be used as a
-				    whole.  Each release provides new files, and sometimes removes old files.
-				    You should therefore <em>not</em> expand the download into the same place as an
-				    existing JMRI installation.  Instead, expand it into a separate location, and
-				    move in to its final destination, completely replacing any previous version of JMRI.<br>
-				    To install, you just have to move that new JMRI folder to where you
-				    want it on your computer.<br>
-                    <br>
-                </li>
+    <h3>Install JMRI</h3>
 
-				<li><a id="startup"></a><strong>Starting JMRI</strong><br>
-                    Installation is complete.<br>
-				    You can run the program by using
-				    the "DecoderPro", "PanelPro", or
-				    "JmriDemo" scripts in the JMRI folder.  Change directory there, and
-				    invoke a script with e.g. "./DecoderPro"
-                </li>
-            </ol>
+    <p>The JMRI package is a complete JMRI implementation.  There is no upgrade process. Any existing
+    installs should be removed or renamed.</p>
 
-		<a id="notes"></a><h2>Notes</h2>
-				<p>You can find some more specific information
-				on the "<a href="FAQLinux.html">JMRI Linux FAQ page</a>".
-				<p>JMRI users have created helpful pages:
-					<ul>
-					<li>Instructions for Fedora on
-					<a href="http://stpaulterminal.org/software/jmri/">david zuhn's pages</a>
-					and
-					<a href="http://trainguy.dyn.dhs.org/~jminer/dcc/Installing_JMRI_on_RedHat_Fedora_Core_3.html">Jon Miner's pages</a>.
-					<li>Instructions for Debian on
-					<a href="http://www.jerrard.ca/trains/f4/Debian_DecoderPro.html">Tom Jerrard's website</a>,
-					including a great description of how to
-					<a href="http://www.jerrard.ca/trains/f4/ICON.pdf">add an icon to the desktop</a>.
-					</ul>
+    <p>If custom components have been added to a JMRI install, they will need to be copied somewhere
+    safe before removing an old version.  To minimize the risk of losing custom components, they
+    should be in the <strong>user files location</strong>.  Profiles and other user data is in the
+    <strong>~/.jmri</strong> directory.</p>
+
+    <p>The recommended install location is the user's <strong><em>home</em></strong> directory.
+    This reduces the possibility of OS or other application issues.  The <strong>tar</strong> command is used to
+    extract the JMRI directory.</p>
+
+    <code>tar xzf &lt;file name&gt; -C ~</code>
+
+    <p>Replace <strong><em>&lt;file name&gt;</em></strong> with the downloaded file name. The
+    <strong><em>-C ~</em></strong> writes the output to the home directory.</p>
+
+    <div class="noted">
+      <p>The <strong>tar</strong> command works on all Linux distributions.  Most distributions also
+      have a GUI tool to expand compressed tar files.  This is accessed using the file manager right
+      click context menu for the downloaded tar file.</p>
+
+      <dl>
+        <dt>Mint</dt>
+        <dd>
+          <p><strong>Open With Archive Manager</strong> &mdash; When the archive opens, click on
+          <strong>Extract</strong>.  The next page is used to select the destination, such as
+          <strong>Home</strong>.  Then click on <strong>Extract</strong>.</p>
+
+          <p><strong>Extract Here</strong> &mdash; Extracts JMRI to the current location. Move the
+          extracted JMRI directory to the desired location or move the downloaded file first.</p>
+        </dd>
+
+        <dt>Ubuntu</dt>
+        <dd>
+          <p><strong>Open With Archive Manager</strong> &mdash; Same as Mint.</p>
+
+          <p><strong>Extract Here</strong> &mdash; Extracts JMRI to the current location but within
+          a new directory.  Open the directory and move the extracted JMRI directory to the desired
+          location.</p>
+
+          <p><strong>Extract To...</strong> &mdash; After selecting a destination location such as
+          <strong>Home</strong>, extracts JMRI within a new directory.  Open the directory and move
+          the extracted JMRI directory to the desired location.</p>
+        </dd>
+
+        <dt>CentOS</dt>
+        <dd>
+          <p><strong>Extract Here</strong> &mdash; Same as Ubuntu.</p>
+
+          <p><strong>Extract To...</strong> &mdash; Same as Ubuntu.</p>
+        </dd>
+
+        <dt>Raspberry Pi OS</dt>
+        <dd>
+          <p><strong>Archiver</strong> &mdash; After the JMRI tar file is loaded, click on
+          <strong>JMRI</strong> and then the Extract files <strong>icon</strong>.  Select the
+          destination such as <strong>Home</strong> and click on <strong>Open</strong>.  Then click
+          on <strong>Extract</strong>.</p>
+
+          <p><strong>Extract Here</strong> &mdash; Same as Mint.</p>
+
+          <p><strong>Extract To...</strong> &mdash; After selecting a destination location such as
+          <strong>Home</strong>, click on <strong>Open</strong>.  Then click on <strong>Extract</strong>.</p>
+        </dd>
+      </dl>
+
+    </div>
+
+    <h4>Desktop Icons</h4>
+      <p>Desktop icons are not required.  PanelPro and DecoderPro can be started by clicking on the
+      scripts within the JMRI install in the file manager or from the command line.  For example:
+      <code>~/JMRI/PanelPro</code></p>
+
+      <h5>Mint</h5>
+
+      <p>Use the create launcher desktop action.</p>
+      <ol>
+        <li>Right click on the desktop and select <strong>Create a new launcher here...</strong>.</li>
+        <li>Enter the icon name.</li>
+        <li>Use the <strong>Browse</strong> button to select the PanelPro or DecoderPro script in
+        the JMRI directory.</li>
+        <li>The Comment is optional.</li>
+        <li>Leave <strong>Launch in Terminal</strong> unchecked.</li>
+        <li>Click on the icon.</li>
+        <li>Use the <strong>Browse</strong> button to find the icon in <strong>JMRI/resources</strong>.</li>
+        <li>After selecting the icon, click on the icon in pallet and click on <strong>Select</strong>.</li>
+        <li>Click <strong>OK</strong></li>
+      </ol>
+
+      <p>Note:  The following technique also works for Mint.</p>
+
+      <h5>Others</h5>
+
+      <p>The other distributions require a <strong>desktop</strong> file which defines the
+      application. Use a text editor to create the DecoderPro and PanelPro files.  For Debian based
+      distributions, the files are stored at <strong><em>~/Desktop</em></strong>. For Red Hat
+      distributions, they are stored at <strong><em>~/.local/shared/applications</em></strong>.</p>
+
+      <dl>
+        <dt>DecoderPro.desktop</dt>
+        <dd><pre>
+[Desktop Entry]
+Type=Application
+Encoding=UTF-8
+Name=DecoderPro
+Comment=JMRI Decoder Pro
+Icon=/home/&lt;username&gt;/JMRI/resources/decoderpro.gif
+Exec=/home/&lt;username&gt;/JMRI/DecoderPro
+Terminal=false;
+        </pre></dd>
+
+        <dt>PanelPro.desktop</dt>
+        <dd><pre>
+[Desktop Entry]
+Type=Application
+Encoding=UTF-8
+Name=PanelPro
+Comment=JMRI Panel Pro
+Icon=/home/&lt;username&gt;/JMRI/resources/PanelPro.gif
+Exec=/home/&lt;username&gt;/JMRI/PanelPro
+Terminal=false;
+        </pre></dd>
+      </dl>
+
+      <p>Change <strong>&lt;username&gt;</strong> to the actual user name.</p>
+
+      <p>After the icons have been created they need to be made executable.  Note:  The desktop files
+      on Raspberry Pi OS and CentOS do not need to be executable.</p>
+
+      <ol>
+        <li>Right click on the icon and select <strong>Properties</strong>.</li>
+        <li>Select the <strong>Permissions</strong> tab.</li>
+        <li>Enable <strong>Allow executing file as program</strong></li>
+        <li>Click on <strong>Close</strong></li>
+      </ol>
+
+      <p class="noted">The icon setup only needs to be done on the first install.  The icons will
+      continue to work when the JMRI install directory is replaced by a new download and extract.</p>
+
+    <h3>Notes</h3>
+
+    <p>The JMRI user data is located at <strong>~/.jmri</strong>.  This is a hidden directory.  Some
+    applications ignore hidden directories.  The Linux file manager normally has an option to make
+    the hidden directories visible.  A symbolic link can be used to provide a substitute reference.
+    At the home directory, enter <code>ln -s .jmri jmri</code> in a terminal window.
+
+    <p>The JMRI project is continuously adding features, bug fixes, examples and tutorials to the
+    release, and so new "test" versions appear about once a month.  These are announced in the
+    "JMRI users" Groups.io discussion group at
+    <a href="https://groups.io/g/jmriusers">https://groups.io/g/jmriusers</a>.
+
+    <p>Additional information can be found at the "<a href="FAQLinux.html">JMRI Linux FAQ page</a>".
 
     <!--#include virtual="/Footer.shtml" -->
     </div><!-- closes #mainContent-->

--- a/install/LinuxOld.shtml
+++ b/install/LinuxOld.shtml
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+ <title>
+ JMRI: Linux Install Guide
+ </title>
+    <meta name="Author" content="Bob Jacobsen">
+    <meta name="keywords" content="java model railroad JMRI install Linux">
+    <!--#include virtual="/Style.shtml" -->
+</head>
+
+<body>
+<!--#include virtual="/Header.shtml" -->
+<div id="mBody">
+<!--#include virtual="Sidebar.shtml" -->
+  <div id="mainContent">
+
+  <h1>JMRI Install Guide: Linux</h1>
+		<ul class="snav"><!-- TOC -->
+		<li><a href="#installation">Installation</a>
+		<li><a href="#startup">Starting JMRI</a>
+		<li><a href="#notes">Notes</a>
+		</ul>
+
+      This page describes general aspects of installing JMRI on Linux.
+
+      <p>
+      There are multiple versions of Linux, all slightly different and
+      requiring installation instructions that differ in detail.
+      There are specific pages describing details of
+      installation on
+				<ul>
+				<li><a href="Mint20.shtml">Mint 20</a> (no command line use)
+				<li><a href="Ubuntu.shtml">Ubuntu</a>
+				<li><a href="decTop.shtml">Xubuntu</a> (on a decTOP small computer)
+				<li><a href="OpenSUSE.shtml">Open SUSE</a>
+				<li><a href="Mint.shtml">Mint</a>
+				</ul>
+
+			There are also detailed instructions for installing on a
+				<ul>
+				<li><a href="Raspbian.shtml">Raspberry Pi</a></li>
+				<li><a href="EeePC.shtml">EeePC</a></li>
+				<li><a href="OLPC_XO.shtml">OLPC (One Laptop Per Child) XO</a></li>
+				</ul>
+
+	        Some Linux distributions have associated repositories that make it easier to
+	        install software.  If you have one of those, you can find more info at:
+	            <ul>
+	            <li><a href="https://slackbuilds.org/apps/jmri/">Slackware</a>
+	            </ul>
+			<p>
+            The general procedure to install JMRI is:</p>
+
+            <ol>
+				<li>Determine if your hardware supports Java and JMRI<br>
+                <br>
+				<a name="sysreq"></a><strong>JMRI System Requirements</strong><br>
+				Using JMRI requires a combination of hardware (in this case running Linux), Java software and a JMRI
+                download for a specific version.
+                <ul>
+                    <li>JMRI&reg; version 5.x requires Java 11</li>
+                    <li>Version 4.2 requires Java 1.8</li>
+                    <li>Version 3.10.1 requires Java 1.6 or later</li>
+                    <li>Version 2.14.1 requires Java 1.5 (or 1.6 if you wish for drag &amp; drop)</li>
+                    <li>Version 2.12 requires Java 1.5 or later</li>
+				</ul>
+
+                <br>These steps outline how to install DecoderPro on Linux.
+				They should work for Red Hat 8, 9 and 10. They don't
+				work on RedHat 7.<br>
+
+				(For other versions of Linux, please
+				see the first item in our
+				<a href="FAQLinux.html">JMRI Linux FAQ</a>).<br>
+
+				You'll need the correct serial port or USB port
+				to attach to your layout hardware.  JMRI is compatible
+				with USB-to-Serial adapters, so long as they have
+				Linux drivers that make them look like regular serial ports.
+				For troubleshooting, see the
+				<a href="FAQLinux.html#usb">FAQ</a><br>
+                <br>
+                </li>
+
+				<li>Get and Install Java (if needed)<br>
+
+				To see if you have a version of Java already installed, in Terminal enter:<br>
+				<code> sh> java -version</code>
+                <br>
+				If the Java version is 1.8 or later, you may be fine, but
+                be aware that if you did not install Java on your system
+                yourself, some systems have Java only partially installed. They
+                will respond correctly to the above command, but still are not
+                all there. If your system does not have Java in the environment
+                variable PATH, the install is probably not complete. Check with
+                the system manager or do a fresh Java installation.<br>
+
+				If it is not at least 1.8, or if you get a "java: not found"
+				error, you will need to install it.<br>
+                <br>
+				Most Linux distributions can get an automated install download
+				from Oracle by clicking on this button:<br>
+				<a href="http://www.java.com" target="_blank">
+				<img src="https://download.oracle.com/technetwork/java/get-java/getjavasoftware-88x31.png" alt="Get Java Software" />
+				</a>
+                <br>
+				If that doesn't work or you need to manually install Java,
+				you can find further information on the
+				<a href="http://www.oracle.com/technetwork/java/javase/downloads/index.html"> Oracle Java downloads page</a>.
+				    <ul>
+				    <li>Java comes in several forms:
+				    JMRI needs the Standard Edition (SE) version, but
+				    Java EE is also OK;<br>
+				    neither Java ME or Java Embedded are sufficient.
+				    <li>There are also different Java SE installers: JMRI can
+				    run with either a proper SDK (Software Development Kit, for compiling and running Java)
+				    or JRE (Java Runtime Environment, for just running Java) installation.
+				    <li>
+				    Note: JMRI up to 4.99 was developed with Java 1.8. It should work fine with later versions (Java
+                    1.9, Java 10, 11, etc)
+	                but you may get a message about "WARNING: An illegal reflective access operation has occurred" and
+                    "WARNING: Please consider reporting this to the maintainers".
+	                We know about this; you can ignore the messages.
+				    </ul>
+                </li>
+
+
+				<li>Give user-level application access to serial ports<br>
+				    <code>chmod 666 /dev/ttyS0</code><br>
+				    <code>chmod 666 /dev/ttyS1</code>
+				    </li>
+				<li>
+				   Give user access to lock files (required on Red Hat).
+				   Edit <code>/etc/group</code> &amp; <code>/etc/gshadow</code> to add 'user' to the 'uucp' and 'lock'
+				   groups.</li>
+
+				<li>Get JMRI
+				    <a href="../download/index.shtml#prod-rel">Download</a> a version of JMRI, either the
+				    latest production version, or a "test version".  Since the version
+				    numbers change with every release, this link takes you to the general
+				    JMRI download page, where you can select whichever version you like.<br>
+
+				    The JMRI project is continuously adding features, bug fixes,
+				    examples and tutorials to the release, and so a new "test" versions
+				    appear every couple of weeks.  You may find one of these has features
+				    that you really want.  These are announced in the "JMRI users" Groups.io
+				    discussion group at
+				    <a
+				     href="https://groups.io/g/jmriusers">https://groups.io/g/jmriusers</a>.<br>
+                    <br>
+                </li>
+
+				<li><a id="update"></a>Install JMRI<br>
+				    Uncompress/untar the file you downloaded above.  This will create a new "JMRI" folder.<br>
+				    Note: Each JMRI release is an independent set of files: It's intended to be used as a
+				    whole.  Each release provides new files, and sometimes removes old files.
+				    You should therefore <em>not</em> expand the download into the same place as an
+				    existing JMRI installation.  Instead, expand it into a separate location, and
+				    move in to its final destination, completely replacing any previous version of JMRI.<br>
+				    To install, you just have to move that new JMRI folder to where you
+				    want it on your computer.<br>
+                    <br>
+                </li>
+
+				<li><a id="startup"></a><strong>Starting JMRI</strong><br>
+                    Installation is complete.<br>
+				    You can run the program by using
+				    the "DecoderPro", "PanelPro", or
+				    "JmriDemo" scripts in the JMRI folder.  Change directory there, and
+				    invoke a script with e.g. "./DecoderPro"
+                </li>
+            </ol>
+
+		<a id="notes"></a><h2>Notes</h2>
+				<p>You can find some more specific information
+				on the "<a href="FAQLinux.html">JMRI Linux FAQ page</a>".
+				<p>JMRI users have created helpful pages:
+					<ul>
+					<li>Instructions for Fedora on
+					<a href="http://stpaulterminal.org/software/jmri/">david zuhn's pages</a>
+					and
+					<a href="http://trainguy.dyn.dhs.org/~jminer/dcc/Installing_JMRI_on_RedHat_Fedora_Core_3.html">Jon Miner's pages</a>.
+					<li>Instructions for Debian on
+					<a href="http://www.jerrard.ca/trains/f4/Debian_DecoderPro.html">Tom Jerrard's website</a>,
+					including a great description of how to
+					<a href="http://www.jerrard.ca/trains/f4/ICON.pdf">add an icon to the desktop</a>.
+					</ul>
+
+    <!--#include virtual="/Footer.shtml" -->
+    </div><!-- closes #mainContent-->
+  </div> <!-- closes #mBody, started in sidebar-->
+<script src="/js/main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
- The original install page has been moved to LinuxOld.shtml.
- The updated page is for JMRI 5+ with Java 11.  
- The content supports most if not all Debian and Red Hat based distributions.  
- Broken links and links to outdated information have been removed.

