### PR TITLE
Update Release Notes for 5.6

### DIFF
--- a/releasenotes/jmri5.6.shtml
+++ b/releasenotes/jmri5.6.shtml
@@ -538,7 +538,7 @@ in those is
                   including activating a reversed route if the Entry/Exit pair has the <strong>Both Way</strong>
                   option enabled.</li>
               <li>The action <strong>Audio</strong>
-                  no longer let the user select an Audio buffer when edition the action/expression.
+                  no longer let the user select an Audio buffer when edition the action.
                   LogixNG can only act on or listen to Audio sources and the Audio listener so there
                   is no point in selecting an audio buffer for LogixNG.</li>
             </ul>

--- a/releasenotes/jmri5.6.shtml
+++ b/releasenotes/jmri5.6.shtml
@@ -539,7 +539,7 @@ in those is
                   option enabled.</li>
               <li>The action <strong>Audio</strong>
                   no longer let the user select an Audio buffer when edition the action.
-                  LogixNG can only act on or listen to Audio sources and the Audio listener so there
+                  LogixNG can only act on Audio sources and the Audio listener so there
                   is no point in selecting an audio buffer for LogixNG.</li>
             </ul>
           </li>

--- a/releasenotes/jmri5.6.shtml
+++ b/releasenotes/jmri5.6.shtml
@@ -483,7 +483,7 @@ in those is
                 to a hyphen ("-") when there's no information available to reduce screen
                 clutter on complex panels.
 	        <li>Labels and icons on a panel can now have one or more classes. This is useful if the label/icon is controlled by LogixNG.</li>
-	        <li>add option(s) for restoring block values, issue #12459</li>
+	        <li>Add option(s) for restoring block values, issue #12459</li>
 	        <li>The LogixNG Icon has been added to the toolbars.  The LogixNG Icon can run inline
 	            LogixNGs by clicking on the icon or text label when converted to text.</li>
 	        <li>The Audio Icon has been added to the toolbars.  The Audio Icon can play a sound

--- a/releasenotes/jmri5.6.shtml
+++ b/releasenotes/jmri5.6.shtml
@@ -499,81 +499,91 @@ in those is
     <h3>LogixNG</h3>
         <a id="LogixNG" name="LogixNG"></a>
         <ul>
-          <li>The expression <strong>File as flag</strong> has been added. It returns true if
-              a particular file exists.</li>
-          <li>The <strong>Icon/Label by class on panel</strong> action is added.
-              It allows LogixNG to control all icons/labels of a class.</li>
-          <li>The <strong>Audio</strong> expression has been added. It lets
-              LogixNG listen on an Audio and take appropriate action.</li>
-          <li>A new <strong>LogixNG</strong> icon has been added to Panel Editor.
-          When the icon is clicked, it will execute the inline LogixNG of that icon.
-          If the inline LogixNG has several ConditionalNGs, the ConditionalNGs will
-          be executed in the order they got created.</li>
-          <li>A new option is added to the <strong>ConditionalNG</strong> table when
-          editing a LogixNG. By default, all the ConditionalNGs are executed when the
-          panel is loaded if the LogixNG is enabled. But if the <strong>Startup</strong>
-          checkbox is unchecked, the ConditionalNG will not be executed when the panel
-          is loaded. This is in particular useful for the <strong>LogixNG</strong> icon
-          that's added in this JMRI version.</li>
-          <li>A new tool <strong>Where Used</strong> has been added to LogixNG.
-          It shows where in the LogixNG tree an item is used. The tool is found
-          on menu item <strong>Tools &rArr; LogixNG &rArr; Where Used</strong>.</li>
-          <li>A bug in the LogixNG action <strong>Logix</strong> has been fixed. The Logix
-          feature <strong>When triggered</strong> didn't work with the LogixNG action
-          <strong>Logix</strong> but has now been resolved.</li>
-          <li>The action <strong>On Change</strong> has been renamed to <strong>Logix Action</strong>.
-          <li>The action <strong>Audio</strong> and the expression <strong>Audio</strong>
-          no longer let the user select an Audio buffer when edition the action/expression.
-          LogixNG can only act on or listen to Audio sources and the Audio listener so there
-          is no point in selecting an audio buffer for LogixNG.</li>
           <li><strong>Note:</strong> If tables and panels are stored with this JMRI version, the file
           might not load in a previous version of JMRI if it includes LogixNG. This is because JMRI
           now stores some LogixNG data in a different way than before.</li>
-
-          <li>The expression <strong>Timer</strong> has been added. It returns <strong>False</strong>
-          until some time has passed. It then returns <strong>True</strong> once and the timer starts
-          again. This expression is intended to be used together with the action <strong>Sequence</strong>.</li>
-
-          <li>The action <strong>Throttle function</strong> has been added. It's similar to the action
-          <strong>Throttle</strong>, except that it only sets a function, not speed or direction, and
-          that it doesn't have any child actions.</li>
-
-          <li>The action <strong>Sequence</strong> is now safe to use in LogixNG modules. The action
-          had a bug which made it sometimes fail if it was used in a module and that module was called
-          from several ConditionalNGs at once.</li>
-
-          <li>When a LogixNG was created and ConditionalNGs
-          was created for that LogixNG, the ConditionalNGs
-          wasn't executing until restart of JMRI if the
-          ConditionalNGs had the <strong>Startup</strong>
-          flag unchecked. That's fixed now.</li>
-
-          <li>Warrant expression was not listening for warrant events.  Fixed along with the long
-          description.</li>
-
-          <li>Add the <strong>GET_BLOCK_WARRANT</strong> and <strong>GET_BLOCK_TRAIN_NAME</strong>
-          OBlock actions to the OBlock Logix import.</li>
-
-          <li>The action <strong>Timer</strong> has been improved. It can now be used within a
-          LogixNG module. It also supports local variables to tell the different delays for the
-          timers in the Timer action.<br>
-          To use the Timer action in a LogixNG module, have an <strong>Always true</strong>
-          expression as <strong>Start</strong> expression for the Timer action, together with the
-          option <strong>Start/Stop by Start expression</strong> selected.</strong></li>
-
-          <li>The action <strong>Audio icon on web panel</strong> is added to the category
-          <strong>Display</strong>. This action can tell an <strong>Audio</strong> icon on
-          a Panel editor to play the sound when the panel is shown in a web browser, for
-          example on a tablet or mobile phone.</li>
-
-          <li>The action <strong>Block</strong> and the expressions <strong>Block</strong>,
-          <strong>Dispatcher</strong> and <strong>Sensor</strong> has been refactored.</li>
-
-          <li>The expression <strong>Entry/exit</strong> can now check if a
-          entry/exit is reversed or bidirectional.</li>
-          <li>The <strong>Entry/Exit</strong> action can activate and deactivate Entry/Exit routes,
-          including activating a reversed route if the Entry/Exit pair has the <strong>Both Way</strong>
-          option enabled.</li>
+          <br>
+          <li>New actions
+            <ul>
+              <li>The <strong>Icon/Label by class on panel</strong> action is added.
+                  It allows LogixNG to control all icons/labels of a class.</li>
+              <li>The action <strong>Throttle function</strong> has been added. It's similar to the action
+                  <strong>Throttle</strong>, except that it only sets a function, not speed or direction, and
+                  that it doesn't have any child actions.</li>
+              <li>The action <strong>Audio icon on web panel</strong> is added to the category
+                  <strong>Display</strong>. This action can tell an <strong>Audio</strong> icon on
+                  a Panel editor to play the sound when the panel is shown in a web browser, for
+                  example on a tablet or mobile phone.</li>
+              <li>The action <strong>Timer</strong> has been improved. It can now be used within a
+                  LogixNG module. It also supports local variables to tell the different delays for the
+                  timers in the Timer action.<br>
+                  To use the Timer action in a LogixNG module, have an <strong>Always true</strong>
+                  expression as <strong>Start</strong> expression for the Timer action, together with the
+                  option <strong>Start/Stop by Start expression</strong> selected.</strong></li>
+              <li>The action <strong>Block</strong> and the expressions <strong>Block</strong>,
+                  <strong>Dispatcher</strong> and <strong>Sensor</strong> has been refactored.</li>
+            </ul>
+          </li>
+          <br>
+          <li>Improved actions
+            <ul>
+              <li>The action <strong>Sequence</strong> is now safe to use in LogixNG modules. The action
+                  had a bug which made it sometimes fail if it was used in a module and that module was called
+                  from several ConditionalNGs at once.</li>
+              <li>A bug in the LogixNG action <strong>Logix</strong> has been fixed. The Logix
+                  feature <strong>When triggered</strong> didn't work with the LogixNG action
+                  <strong>Logix</strong> but has now been resolved.</li>
+              <li>The action <strong>On Change</strong> has been renamed to <strong>Logix Action</strong>.
+              <li>The <strong>Entry/Exit</strong> action can activate and deactivate Entry/Exit routes,
+                  including activating a reversed route if the Entry/Exit pair has the <strong>Both Way</strong>
+                  option enabled.</li>
+              <li>The action <strong>Audio</strong>
+                  no longer let the user select an Audio buffer when edition the action/expression.
+                  LogixNG can only act on or listen to Audio sources and the Audio listener so there
+                  is no point in selecting an audio buffer for LogixNG.</li>
+            </ul>
+          </li>
+          <br>
+          <li>New expressions
+            <ul>
+              <li>The expression <strong>File as flag</strong> has been added. It returns true if
+                  a particular file exists.</li>
+              <li>The <strong>Audio</strong> expression has been added. It lets
+                  LogixNG listen on an Audio and take appropriate action.</li>
+              <li>The expression <strong>Timer</strong> has been added. It returns <strong>False</strong>
+                  until some time has passed. It then returns <strong>True</strong> once and the timer starts
+                  again. This expression is intended to be used together with the action <strong>Sequence</strong>.</li>
+            </ul>
+          </li>
+          <br>
+          <li>Improved expressions
+            <ul>
+              <li>Warrant expression was not listening for warrant events.  Fixed along with the long
+                  description.</li>
+              <li>The expression <strong>Entry/exit</strong> can now check if a
+                  entry/exit is reversed or bidirectional.</li>
+            </ul>
+          </li>
+          <br>
+          <li>Other improvements
+            <ul>
+              <li>A new <strong>LogixNG</strong> icon has been added to Panel Editor.
+                  When the icon is clicked, it will execute the inline LogixNG of that icon.
+                  If the inline LogixNG has several ConditionalNGs, the ConditionalNGs will
+                  be executed in the order they got created.</li>
+              <li>A new option is added to the <strong>ConditionalNG</strong> table when
+                  editing a LogixNG. By default, all the ConditionalNGs are executed when the
+                  panel is loaded if the LogixNG is enabled. But if the <strong>Startup</strong>
+                  checkbox is unchecked, the ConditionalNG will not be executed when the panel
+                  is loaded. This is in particular useful for the <strong>LogixNG</strong> icon
+                  that's added in this JMRI version.</li>
+              <li>A new tool <strong>Where Used</strong> has been added to LogixNG.
+                  It shows where in the LogixNG tree an item is used. The tool is found
+                  on menu item <strong>Tools &rArr; LogixNG &rArr; Where Used</strong>.</li>
+              <li>Add the <strong>GET_BLOCK_WARRANT</strong> and <strong>GET_BLOCK_TRAIN_NAME</strong>
+                  OBlock actions to the OBlock Logix import.</li>
+            </ul>
+          </li>
         </ul>
 
     <h3>Operations</h3>


### PR DESCRIPTION
This PR reorganize the updates to LogixNG to make it easier for the users to see what has happened.

```
<li>The action <strong>Audio</strong> and the expression <strong>Audio</strong>
    no longer let the user select an Audio buffer when edition the action/expression.
    LogixNG can only act on or listen to Audio sources and the Audio listener so there
    is no point in selecting an audio buffer for LogixNG.</li>
```
The expression Audio was added in a test release in [5.5.4](https://github.com/JMRI/JMRI/pull/12311) and audio buffers where filtered in [5.5.5](https://github.com/JMRI/JMRI/pull/12446). Users that only install production releases will not have any Audio expression with audio buffers. But the Audio action has been there from the beginning of LogixNG. For that reason, I have this comment only for the Audio action, not for the Audio expression in this release note.