### PR TITLE
LocoNet-LCC gateway B8f->B8g update warning

### DIFF
--- a/releasenotes/jmri5.7.7.shtml
+++ b/releasenotes/jmri5.7.7.shtml
@@ -124,7 +124,10 @@ from
 <h3>New warnings for this release:</h3>
 
 <ul>
-    <li>None Yet</li>
+    <li>If you are using a RR-CirKits LocoNet to LCC gateway
+        with this release, please upgrade its firmware
+        to version B8g or later.  B8f or earlier will 
+        have trouble updating the gateway's configuration.</li>
 </ul>
 
 

--- a/releasenotes/jmri5.7.8.shtml
+++ b/releasenotes/jmri5.7.8.shtml
@@ -138,6 +138,11 @@ before installing this test release.
 See <a href="#update">instructions above</a>.
 
 <ul>
+    <li><span class="since">Since <a href="jmri4.7.7.shtml">JMRI 4.7.7</a></span>
+        If you are using a RR-CirKits LocoNet to LCC gateway
+        with this release, please upgrade its firmware
+        to version B8g or later.  B8f or earlier will 
+        have trouble updating the gateway's configuration.</li>
     <li><span class="since">Since <a href="jmri4.99.1.shtml">JMRI 4.99.1</a></span>
         This test release, and all subsequent ones, require the use of
         Java 11 or later.  Java 8 is explicitly not supported.

--- a/releasenotes/jmri5.7.9.shtml
+++ b/releasenotes/jmri5.7.9.shtml
@@ -139,6 +139,11 @@ before installing this test release.
 See <a href="#update">instructions above</a>.
 
 <ul>
+    <li><span class="since">Since <a href="jmri4.7.7.shtml">JMRI 4.7.7</a></span>
+        If you are using a RR-CirKits LocoNet to LCC gateway
+        with this release, please upgrade its firmware
+        to version B8g or later.  B8f or earlier will 
+        have trouble updating the gateway's configuration.</li>
     <li><span class="since">Since <a href="jmri4.99.1.shtml">JMRI 4.99.1</a></span>
         This test release, and all subsequent ones, require the use of
         Java 11 or later.  Java 8 is explicitly not supported.

--- a/releasenotes/jmri5.8.shtml
+++ b/releasenotes/jmri5.8.shtml
@@ -109,6 +109,11 @@ from
 <h3>New warnings for this production release:</h3>
 
 <ul>
+    <li><span class="since">Since <a href="jmri4.7.7.shtml">JMRI 4.7.7</a></span>
+        If you are using a RR-CirKits LocoNet to LCC gateway
+        with this release, please upgrade its firmware
+        to version B8g or later.  B8f or earlier will 
+        have trouble updating the gateway's configuration.</li>
     <li><span class="since">Since <a href="jmri5.7.1.shtml">JMRI 5.7.1</a></span>
         Several systems have had extensive updates to their serial
         support.  If you have trouble connecting to your layout hardware

--- a/releasenotes/jmri5.9.1.shtml
+++ b/releasenotes/jmri5.9.1.shtml
@@ -155,6 +155,11 @@ See <a href="#update">instructions above</a>.
         <a href="https://groups.io/g/jmriusers">on the JMRIusers list</a>
         for assistance.
     </li>
+    <li><span class="since">Since <a href="jmri4.7.7.shtml">JMRI 4.7.7</a></span>
+        If you are using a RR-CirKits LocoNet to LCC gateway
+        with this release, please upgrade its firmware
+        to version B8g or later.  B8f or earlier will 
+        have trouble updating the gateway's configuration.</li>
 
 </ul>
 

--- a/releasenotes/jmri5.9.2.shtml
+++ b/releasenotes/jmri5.9.2.shtml
@@ -155,6 +155,11 @@ See <a href="#update">instructions above</a>.
         <a href="https://groups.io/g/jmriusers">on the JMRIusers list</a>
         for assistance.
     </li>
+    <li><span class="since">Since <a href="jmri4.7.7.shtml">JMRI 4.7.7</a></span>
+        If you are using a RR-CirKits LocoNet to LCC gateway
+        with this release, please upgrade its firmware
+        to version B8g or later.  B8f or earlier will 
+        have trouble updating the gateway's configuration.</li>
 
 </ul>
 

--- a/releasenotes/jmri5.9.3.shtml
+++ b/releasenotes/jmri5.9.3.shtml
@@ -161,6 +161,11 @@ See <a href="#update">instructions above</a>.
         <a href="https://groups.io/g/jmriusers">on the JMRIusers list</a>
         for assistance.
     </li>
+    <li><span class="since">Since <a href="jmri4.7.7.shtml">JMRI 4.7.7</a></span>
+        If you are using a RR-CirKits LocoNet to LCC gateway
+        with this release, please upgrade its firmware
+        to version B8g or later.  B8f or earlier will 
+        have trouble updating the gateway's configuration.</li>
 
 </ul>
 


### PR DESCRIPTION
Add warning to recent release notes that RR-Cirkits LocoBuffer-LCC Gateway users need to update their gateway to the most recent version to use the release.